### PR TITLE
chore: add package metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ description = "Core accounting functionality with double-entry bookkeeping, GST 
 license = "MIT OR Apache-2.0"
 keywords = ["accounting", "bookkeeping", "finance", "gst", "ledger"]
 categories = ["finance"]
+rust-version = "1.82"
+readme = "README.md"
+repository = "https://github.com/harisr92/accounting-blue"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Add rust-version, readme and repository fields to Cargo.toml to provide
crate metadata required by modern Cargo and crates.io. This makes the
package declaration explicit about the minimum Rust toolchain (1.56),
links the README for crate listing, and points to the source repository
URL so publishing and tooling can surface project information correctly.