### PR TITLE
refactor-unify-listing-pagination

### DIFF
--- a/PAGINATION_EXAMPLES.md
+++ b/PAGINATION_EXAMPLES.md
@@ -1,0 +1,259 @@
+# Pagination Examples
+
+This document provides a comprehensive guide to the pagination examples included with the accounting-core library.
+
+## Available Examples
+
+### 1. `pagination_demo.rs` - Complete Pagination Walkthrough
+
+A comprehensive demonstration of all pagination features including:
+
+- **Basic Account Pagination**: List accounts with different page sizes
+- **Filtered Pagination**: Filter by account type while paginating
+- **Transaction Pagination**: Paginate transactions with date filtering
+- **Account-Specific Transactions**: Get transactions for a specific account
+- **Navigation Helpers**: Build pagination controls for user interfaces
+- **Error Handling**: Proper validation and error responses
+- **UI Helpers**: Practical examples for building pagination UIs
+
+**Run the example:**
+```bash
+cargo run --example pagination_demo
+```
+
+**Key features demonstrated:**
+- `PaginationParams::new(page, page_size)` validation
+- `PaginatedResponse` metadata usage
+- Navigation between pages
+- Real-world pagination scenarios
+
+### 2. `api_pagination_patterns.rs` - REST API and GraphQL Patterns
+
+Shows how to integrate pagination with modern API patterns:
+
+- **REST API Patterns**: Traditional query parameter handling
+- **GraphQL Pagination**: Cursor-based pagination with edges/nodes
+- **Infinite Scroll**: Mobile-friendly batch loading
+- **Data Table Pagination**: Server-side table pagination with sorting
+
+**Run the example:**
+```bash
+cargo run --example api_pagination_patterns
+```
+
+**API styles demonstrated:**
+- REST: `GET /accounts?page=1&limit=10&type=asset`
+- GraphQL: `accounts(first: 5, after: cursor) { edges { node } }`
+- Infinite scroll: Progressive loading patterns
+- Data tables: Sortable, filterable pagination
+
+### 3. `web_integration.rs` - Web Framework Integration
+
+Demonstrates integration with popular Rust web frameworks:
+
+- **Axum-style**: Query parameters with `serde` deserialization
+- **Actix Web-style**: Request handlers with comprehensive error handling
+- **Warp-style**: Filter-based request processing
+
+**Run the example:**
+```bash
+cargo run --example web_integration
+```
+
+**Framework patterns:**
+- Request parameter validation
+- Response formatting for different frameworks
+- Error handling best practices
+- Header-based metadata (e.g., `X-Total-Count`)
+
+## Common Patterns
+
+### Basic Pagination Setup
+
+```rust
+use accounting_core::{Ledger, PaginationParams};
+
+// Create pagination parameters (validates input)
+let pagination = PaginationParams::new(1, 20)?; // page 1, 20 items
+
+// Get paginated results
+let result = ledger.list_accounts_paginated(pagination).await?;
+
+// Access pagination metadata
+println!("Page {} of {}", result.page, result.total_pages);
+println!("Showing {} of {} total items", result.items.len(), result.total_count);
+
+// Check navigation availability
+if result.has_next {
+    // Load next page
+}
+if result.has_previous {
+    // Load previous page  
+}
+```
+
+### Filtered Pagination
+
+```rust
+use accounting_core::{AccountType, PaginationParams};
+use chrono::NaiveDate;
+
+// Filter by account type
+let pagination = PaginationParams::new(1, 10)?;
+let assets = ledger.list_accounts_by_type_paginated(AccountType::Asset, pagination).await?;
+
+// Filter transactions by date range
+let start_date = NaiveDate::from_ymd_opt(2024, 1, 1);
+let end_date = NaiveDate::from_ymd_opt(2024, 12, 31);
+let transactions = ledger.get_transactions_paginated(start_date, end_date, pagination).await?;
+```
+
+### REST API Response Format
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize)]
+struct ApiResponse<T> {
+    data: Vec<T>,
+    pagination: PaginationMeta,
+}
+
+#[derive(Serialize)]
+struct PaginationMeta {
+    page: u32,
+    per_page: u32,
+    total: u32,
+    total_pages: u32,
+    has_next: bool,
+    has_previous: bool,
+}
+```
+
+### Error Handling
+
+```rust
+use accounting_core::PaginationParams;
+
+// Validation errors are caught early
+match PaginationParams::new(0, 10) {
+    Ok(_) => unreachable!(),
+    Err(e) => println!("Invalid page: {}", e), // "Page must be 1 or greater"
+}
+
+match PaginationParams::new(1, 1001) {
+    Ok(_) => unreachable!(),
+    Err(e) => println!("Invalid page size: {}", e), // "Page size must be between 1 and 1000"
+}
+```
+
+## Running All Examples
+
+To run all examples and see comprehensive pagination functionality:
+
+```bash
+# Run each example individually
+cargo run --example pagination_demo
+cargo run --example api_pagination_patterns  
+cargo run --example web_integration
+
+# Or run tests to verify functionality
+cargo test
+cargo test --doc
+```
+
+## Integration Tips
+
+### Database Integration
+
+When implementing the `LedgerStorage` trait for database backends:
+
+```rust
+// SQL example with LIMIT/OFFSET
+async fn list_accounts_paginated(
+    &self,
+    account_type: Option<AccountType>,
+    pagination: PaginationParams,
+) -> LedgerResult<PaginatedResponse<Account>> {
+    let mut query = "SELECT * FROM accounts".to_string();
+    
+    if let Some(account_type) = account_type {
+        query.push_str(&format!(" WHERE account_type = '{:?}'", account_type));
+    }
+    
+    // Get total count for metadata
+    let count_query = query.replace("SELECT *", "SELECT COUNT(*)");
+    let total_count: u32 = sqlx::query_scalar(&count_query)
+        .fetch_one(&self.pool)
+        .await?;
+    
+    // Add pagination
+    query.push_str(&format!(" ORDER BY id LIMIT {} OFFSET {}", 
+                           pagination.limit(), 
+                           pagination.offset()));
+    
+    let accounts: Vec<Account> = sqlx::query_as(&query)
+        .fetch_all(&self.pool)
+        .await?;
+        
+    Ok(PaginatedResponse::new(
+        accounts,
+        pagination.page,
+        pagination.page_size,
+        total_count,
+    ))
+}
+```
+
+### Frontend Integration
+
+The pagination metadata is designed to work seamlessly with frontend frameworks:
+
+```javascript
+// React example
+function AccountsList({ page, setPage }) {
+  const [accounts, setAccounts] = useState(null);
+  
+  useEffect(() => {
+    fetch(`/api/accounts?page=${page}&limit=20`)
+      .then(res => res.json())
+      .then(data => setAccounts(data));
+  }, [page]);
+  
+  if (!accounts) return <div>Loading...</div>;
+  
+  return (
+    <div>
+      {accounts.data.map(account => <div key={account.id}>{account.name}</div>)}
+      
+      <div className="pagination">
+        {accounts.meta.has_previous && (
+          <button onClick={() => setPage(page - 1)}>Previous</button>
+        )}
+        
+        <span>Page {accounts.meta.page} of {accounts.meta.total_pages}</span>
+        
+        {accounts.meta.has_next && (
+          <button onClick={() => setPage(page + 1)}>Next</button>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+## Performance Considerations
+
+- **Page Size Limits**: The library enforces a maximum page size of 1000 items to prevent memory issues
+- **Database Indexes**: Ensure your database has appropriate indexes on commonly filtered/sorted columns
+- **Caching**: Consider caching total counts for frequently accessed endpoints
+- **Consistent Sorting**: Always use consistent sorting (like ID) to prevent items appearing on multiple pages
+
+## Best Practices
+
+1. **Always validate pagination parameters** before processing requests
+2. **Use appropriate page sizes** - typically 10-50 for UI lists, up to 100 for data exports
+3. **Include comprehensive metadata** in API responses for building navigation
+4. **Handle edge cases** gracefully (empty results, out-of-range pages)
+5. **Consider performance** when dealing with large datasets
+6. **Maintain consistency** in your API response formats across endpoints

--- a/examples/api_pagination_patterns.rs
+++ b/examples/api_pagination_patterns.rs
@@ -1,0 +1,450 @@
+//! Practical API pagination patterns for web applications
+//!
+//! This example shows how to integrate pagination into REST APIs,
+//! handle query parameters, and build efficient data access patterns.
+
+use accounting_core::{
+    AccountType, Ledger, PaginationParams, Account,
+    utils::memory_storage::MemoryStorage,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🌐 API Pagination Patterns Example\n");
+
+    // Setup
+    let storage = MemoryStorage::new();
+    let mut ledger = Ledger::new(storage);
+    setup_sample_accounts(&mut ledger).await?;
+
+    // Simulate different API request patterns
+    rest_api_simulation(&ledger).await?;
+    graphql_pagination_pattern(&ledger).await?;
+    infinite_scroll_pattern(&ledger).await?;
+    table_pagination_pattern(&ledger).await?;
+
+    Ok(())
+}
+
+/// Setup sample accounts for API demonstrations
+async fn setup_sample_accounts(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Create a realistic chart of accounts
+    let accounts = [
+        // Assets
+        ("1000", "Cash - Checking", AccountType::Asset),
+        ("1010", "Cash - Savings", AccountType::Asset),
+        ("1100", "Accounts Receivable", AccountType::Asset),
+        ("1200", "Inventory", AccountType::Asset),
+        ("1500", "Equipment", AccountType::Asset),
+        ("1510", "Accumulated Depreciation - Equipment", AccountType::Asset),
+        ("1600", "Building", AccountType::Asset),
+        ("1610", "Accumulated Depreciation - Building", AccountType::Asset),
+        
+        // Liabilities
+        ("2000", "Accounts Payable", AccountType::Liability),
+        ("2100", "Short-term Loan", AccountType::Liability),
+        ("2200", "Long-term Loan", AccountType::Liability),
+        ("2300", "Accrued Expenses", AccountType::Liability),
+        
+        // Equity
+        ("3000", "Owner's Capital", AccountType::Equity),
+        ("3100", "Retained Earnings", AccountType::Equity),
+        
+        // Income
+        ("4000", "Sales Revenue", AccountType::Income),
+        ("4100", "Service Revenue", AccountType::Income),
+        ("4200", "Interest Income", AccountType::Income),
+        
+        // Expenses
+        ("5000", "Cost of Goods Sold", AccountType::Expense),
+        ("5100", "Rent Expense", AccountType::Expense),
+        ("5200", "Salary Expense", AccountType::Expense),
+        ("5300", "Utilities Expense", AccountType::Expense),
+        ("5400", "Marketing Expense", AccountType::Expense),
+        ("5500", "Office Supplies", AccountType::Expense),
+        ("5600", "Professional Services", AccountType::Expense),
+        ("5700", "Insurance Expense", AccountType::Expense),
+    ];
+
+    for (id, name, account_type) in &accounts {
+        ledger.create_account(
+            id.to_string(),
+            name.to_string(),
+            *account_type,
+            None,
+        ).await?;
+    }
+
+    println!("✅ Created {} sample accounts", accounts.len());
+    Ok(())
+}
+
+/// Simulate REST API request/response patterns
+async fn rest_api_simulation(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔄 REST API Simulation\n");
+
+    // Example 1: GET /api/accounts?page=1&limit=10&type=asset
+    println!("📞 Request: GET /api/accounts?page=1&limit=10&type=asset");
+    let result = api_get_accounts(ledger, ApiAccountsQuery {
+        page: Some(1),
+        limit: Some(10),
+        account_type: Some("asset".to_string()),
+    }).await?;
+    
+    println!("📤 Response:");
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    
+    println!("\n{}\n", "─".repeat(60));
+
+    // Example 2: GET /api/accounts?page=2&limit=5
+    println!("📞 Request: GET /api/accounts?page=2&limit=5");
+    let result = api_get_accounts(ledger, ApiAccountsQuery {
+        page: Some(2),
+        limit: Some(5),
+        account_type: None,
+    }).await?;
+    
+    println!("📤 Response (metadata only):");
+    println!("   Total: {}", result.meta.total);
+    println!("   Page: {} of {}", result.meta.page, result.meta.total_pages);
+    println!("   Items: {}", result.data.len());
+
+    Ok(())
+}
+
+/// Simulate GraphQL-style pagination
+async fn graphql_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔍 GraphQL Pagination Pattern\n");
+
+    // Simulate cursor-based pagination query
+    println!("📞 GraphQL Query:");
+    println!("   accounts(first: 5, after: null, filter: {{ type: EXPENSE }}) {{");
+    println!("     edges {{ node {{ id, name, type }} }}");
+    println!("     pageInfo {{ hasNextPage, hasPreviousPage }}");
+    println!("   }}");
+
+    let result = graphql_get_accounts(ledger, GraphQLAccountsQuery {
+        first: Some(5),
+        after: None,
+        filter: Some(GraphQLAccountFilter {
+            account_type: Some("EXPENSE".to_string()),
+        }),
+    }).await?;
+
+    println!("\n📤 GraphQL Response:");
+    println!("{}", serde_json::to_string_pretty(&result)?);
+
+    Ok(())
+}
+
+/// Simulate infinite scroll pagination
+async fn infinite_scroll_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("♾️  Infinite Scroll Pattern\n");
+
+    let mut loaded_items = 0;
+    let batch_size = 6;
+
+    // Simulate loading 3 batches
+    for batch in 1..=3 {
+        println!("📱 Loading batch {} (infinite scroll):", batch);
+        
+        let pagination = PaginationParams::new(batch, batch_size)?;
+        let result = ledger.list_accounts_paginated(pagination).await?;
+        
+        loaded_items += result.items.len();
+        
+        println!("   ↓ Loaded {} items (total: {}/{})", 
+                 result.items.len(), 
+                 loaded_items, 
+                 result.total_count);
+        
+        // Show last 2 items in this batch
+        for account in result.items.iter().rev().take(2).rev() {
+            println!("     • {} - {}", account.id, account.name);
+        }
+        
+        if !result.has_next {
+            println!("   ✅ All items loaded!");
+            break;
+        }
+        
+        println!("   📜 Scroll for more...\n");
+    }
+
+    Ok(())
+}
+
+/// Simulate data table pagination with sorting and filtering
+async fn table_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("📊 Data Table Pagination\n");
+
+    // Simulate table request with sorting and filtering
+    let table_request = TableRequest {
+        page: 1,
+        page_size: 8,
+        sort_by: "name".to_string(),
+        sort_order: "asc".to_string(),
+        filters: {
+            let mut filters = HashMap::new();
+            filters.insert("type".to_string(), "liability".to_string());
+            filters
+        },
+    };
+
+    println!("🗂️  Table Request:");
+    println!("   Page: {}, Size: {}", table_request.page, table_request.page_size);
+    println!("   Sort: {} {}", table_request.sort_by, table_request.sort_order);
+    println!("   Filters: {:?}", table_request.filters);
+
+    let result = process_table_request(ledger, table_request).await?;
+
+    println!("\n📊 Table Response:");
+    println!("┌─────────┬──────────────────────────────┬─────────────┐");
+    println!("│ Account │ Name                         │ Type        │");
+    println!("├─────────┼──────────────────────────────┼─────────────┤");
+    
+    for account in &result.data {
+        println!("│ {:7} │ {:28} │ {:11} │", 
+                 account.id, 
+                 &account.name[..std::cmp::min(account.name.len(), 28)],
+                 format!("{:?}", account.account_type));
+    }
+    
+    println!("└─────────┴──────────────────────────────┴─────────────┘");
+    println!("Showing {} of {} items | Page {} of {}", 
+             result.data.len(),
+             result.pagination.total_items,
+             result.pagination.current_page,
+             result.pagination.total_pages);
+
+    Ok(())
+}
+
+// API Data Structures
+#[derive(Debug, Deserialize)]
+struct ApiAccountsQuery {
+    page: Option<u32>,
+    limit: Option<u32>,
+    account_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiAccountsResponse {
+    data: Vec<AccountDto>,
+    meta: ApiPaginationMeta,
+}
+
+#[derive(Debug, Serialize)]
+struct AccountDto {
+    id: String,
+    name: String,
+    #[serde(rename = "type")]
+    account_type: String,
+    balance: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiPaginationMeta {
+    page: u32,
+    limit: u32,
+    total: u32,
+    total_pages: u32,
+    has_next: bool,
+    has_previous: bool,
+}
+
+// GraphQL structures
+#[derive(Debug, Deserialize)]
+struct GraphQLAccountsQuery {
+    first: Option<u32>,
+    after: Option<String>,
+    filter: Option<GraphQLAccountFilter>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLAccountFilter {
+    account_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct GraphQLAccountsResponse {
+    data: GraphQLAccountsData,
+}
+
+#[derive(Debug, Serialize)]
+struct GraphQLAccountsData {
+    accounts: GraphQLAccountConnection,
+}
+
+#[derive(Debug, Serialize)]
+struct GraphQLAccountConnection {
+    edges: Vec<GraphQLAccountEdge>,
+    #[serde(rename = "pageInfo")]
+    page_info: GraphQLPageInfo,
+}
+
+#[derive(Debug, Serialize)]
+struct GraphQLAccountEdge {
+    node: AccountDto,
+}
+
+#[derive(Debug, Serialize)]
+struct GraphQLPageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+    #[serde(rename = "hasPreviousPage")]
+    has_previous_page: bool,
+}
+
+// Table structures
+#[derive(Debug)]
+struct TableRequest {
+    page: u32,
+    page_size: u32,
+    sort_by: String,
+    sort_order: String,
+    filters: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+struct TableResponse {
+    data: Vec<Account>,
+    pagination: TablePaginationInfo,
+}
+
+#[derive(Debug)]
+struct TablePaginationInfo {
+    current_page: u32,
+    total_pages: u32,
+    total_items: u32,
+    page_size: u32,
+}
+
+// API Implementation Functions
+
+async fn api_get_accounts(
+    ledger: &Ledger<MemoryStorage>, 
+    query: ApiAccountsQuery
+) -> Result<ApiAccountsResponse, Box<dyn std::error::Error>> {
+    let page = query.page.unwrap_or(1);
+    let limit = query.limit.unwrap_or(20);
+    let pagination = PaginationParams::new(page, limit)?;
+
+    let result = if let Some(type_str) = query.account_type {
+        let account_type = match type_str.to_lowercase().as_str() {
+            "asset" => AccountType::Asset,
+            "liability" => AccountType::Liability,
+            "equity" => AccountType::Equity,
+            "income" => AccountType::Income,
+            "expense" => AccountType::Expense,
+            _ => return Err("Invalid account type".into()),
+        };
+        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+    } else {
+        ledger.list_accounts_paginated(pagination).await?
+    };
+
+    let data = result.items.into_iter().map(|account| AccountDto {
+        id: account.id,
+        name: account.name,
+        account_type: format!("{:?}", account.account_type).to_lowercase(),
+        balance: account.balance.to_string(),
+    }).collect();
+
+    Ok(ApiAccountsResponse {
+        data,
+        meta: ApiPaginationMeta {
+            page: result.page,
+            limit: result.page_size,
+            total: result.total_count,
+            total_pages: result.total_pages,
+            has_next: result.has_next,
+            has_previous: result.has_previous,
+        },
+    })
+}
+
+async fn graphql_get_accounts(
+    ledger: &Ledger<MemoryStorage>,
+    query: GraphQLAccountsQuery,
+) -> Result<GraphQLAccountsResponse, Box<dyn std::error::Error>> {
+    let first = query.first.unwrap_or(10);
+    let page = 1; // In a real implementation, you'd decode the cursor
+    
+    let pagination = PaginationParams::new(page, first)?;
+    
+    let result = if let Some(filter) = query.filter {
+        if let Some(type_str) = filter.account_type {
+            let account_type = match type_str.as_str() {
+                "ASSET" => AccountType::Asset,
+                "LIABILITY" => AccountType::Liability,
+                "EQUITY" => AccountType::Equity,
+                "INCOME" => AccountType::Income,
+                "EXPENSE" => AccountType::Expense,
+                _ => return Err("Invalid account type".into()),
+            };
+            ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+        } else {
+            ledger.list_accounts_paginated(pagination).await?
+        }
+    } else {
+        ledger.list_accounts_paginated(pagination).await?
+    };
+
+    let edges = result.items.into_iter().map(|account| GraphQLAccountEdge {
+        node: AccountDto {
+            id: account.id,
+            name: account.name,
+            account_type: format!("{:?}", account.account_type),
+            balance: account.balance.to_string(),
+        }
+    }).collect();
+
+    Ok(GraphQLAccountsResponse {
+        data: GraphQLAccountsData {
+            accounts: GraphQLAccountConnection {
+                edges,
+                page_info: GraphQLPageInfo {
+                    has_next_page: result.has_next,
+                    has_previous_page: result.has_previous,
+                },
+            },
+        },
+    })
+}
+
+async fn process_table_request(
+    ledger: &Ledger<MemoryStorage>,
+    request: TableRequest,
+) -> Result<TableResponse, Box<dyn std::error::Error>> {
+    let pagination = PaginationParams::new(request.page, request.page_size)?;
+
+    let result = if let Some(type_filter) = request.filters.get("type") {
+        let account_type = match type_filter.as_str() {
+            "asset" => AccountType::Asset,
+            "liability" => AccountType::Liability,
+            "equity" => AccountType::Equity,
+            "income" => AccountType::Income,
+            "expense" => AccountType::Expense,
+            _ => return Err("Invalid account type filter".into()),
+        };
+        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+    } else {
+        ledger.list_accounts_paginated(pagination).await?
+    };
+
+    // Note: In a real implementation, you'd handle sorting at the storage level
+    // For this example, we'll just use the results as-is since they're already sorted by ID
+
+    Ok(TableResponse {
+        data: result.items,
+        pagination: TablePaginationInfo {
+            current_page: result.page,
+            total_pages: result.total_pages,
+            total_items: result.total_count,
+            page_size: result.page_size,
+        },
+    })
+}

--- a/examples/api_pagination_patterns.rs
+++ b/examples/api_pagination_patterns.rs
@@ -4,8 +4,8 @@
 //! handle query parameters, and build efficient data access patterns.
 
 use accounting_core::{
-    Account, AccountType, Ledger, PaginationOption, PaginationParams,
-    utils::memory_storage::MemoryStorage,
+    utils::memory_storage::MemoryStorage, Account, AccountType, Ledger, PaginationOption,
+    PaginationParams,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -29,7 +29,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Setup sample accounts for API demonstrations
-async fn setup_sample_accounts(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn setup_sample_accounts(
+    ledger: &mut Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Create a realistic chart of accounts
     let accounts = [
         // Assets
@@ -38,25 +40,29 @@ async fn setup_sample_accounts(ledger: &mut Ledger<MemoryStorage>) -> Result<(),
         ("1100", "Accounts Receivable", AccountType::Asset),
         ("1200", "Inventory", AccountType::Asset),
         ("1500", "Equipment", AccountType::Asset),
-        ("1510", "Accumulated Depreciation - Equipment", AccountType::Asset),
+        (
+            "1510",
+            "Accumulated Depreciation - Equipment",
+            AccountType::Asset,
+        ),
         ("1600", "Building", AccountType::Asset),
-        ("1610", "Accumulated Depreciation - Building", AccountType::Asset),
-        
+        (
+            "1610",
+            "Accumulated Depreciation - Building",
+            AccountType::Asset,
+        ),
         // Liabilities
         ("2000", "Accounts Payable", AccountType::Liability),
         ("2100", "Short-term Loan", AccountType::Liability),
         ("2200", "Long-term Loan", AccountType::Liability),
         ("2300", "Accrued Expenses", AccountType::Liability),
-        
         // Equity
         ("3000", "Owner's Capital", AccountType::Equity),
         ("3100", "Retained Earnings", AccountType::Equity),
-        
         // Income
         ("4000", "Sales Revenue", AccountType::Income),
         ("4100", "Service Revenue", AccountType::Income),
         ("4200", "Interest Income", AccountType::Income),
-        
         // Expenses
         ("5000", "Cost of Goods Sold", AccountType::Expense),
         ("5100", "Rent Expense", AccountType::Expense),
@@ -69,12 +75,9 @@ async fn setup_sample_accounts(ledger: &mut Ledger<MemoryStorage>) -> Result<(),
     ];
 
     for (id, name, account_type) in &accounts {
-        ledger.create_account(
-            id.to_string(),
-            name.to_string(),
-            *account_type,
-            None,
-        ).await?;
+        ledger
+            .create_account(id.to_string(), name.to_string(), *account_type, None)
+            .await?;
     }
 
     println!("✅ Created {} sample accounts", accounts.len());
@@ -82,40 +85,55 @@ async fn setup_sample_accounts(ledger: &mut Ledger<MemoryStorage>) -> Result<(),
 }
 
 /// Simulate REST API request/response patterns
-async fn rest_api_simulation(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn rest_api_simulation(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("🔄 REST API Simulation\n");
 
     // Example 1: GET /api/accounts?page=1&limit=10&type=asset
     println!("📞 Request: GET /api/accounts?page=1&limit=10&type=asset");
-    let result = api_get_accounts(ledger, ApiAccountsQuery {
-        page: Some(1),
-        limit: Some(10),
-        account_type: Some("asset".to_string()),
-    }).await?;
-    
+    let result = api_get_accounts(
+        ledger,
+        ApiAccountsQuery {
+            page: Some(1),
+            limit: Some(10),
+            account_type: Some("asset".to_string()),
+        },
+    )
+    .await?;
+
     println!("📤 Response:");
     println!("{}", serde_json::to_string_pretty(&result)?);
-    
+
     println!("\n{}\n", "─".repeat(60));
 
     // Example 2: GET /api/accounts?page=2&limit=5
     println!("📞 Request: GET /api/accounts?page=2&limit=5");
-    let result = api_get_accounts(ledger, ApiAccountsQuery {
-        page: Some(2),
-        limit: Some(5),
-        account_type: None,
-    }).await?;
-    
+    let result = api_get_accounts(
+        ledger,
+        ApiAccountsQuery {
+            page: Some(2),
+            limit: Some(5),
+            account_type: None,
+        },
+    )
+    .await?;
+
     println!("📤 Response (metadata only):");
     println!("   Total: {}", result.meta.total);
-    println!("   Page: {} of {}", result.meta.page, result.meta.total_pages);
+    println!(
+        "   Page: {} of {}",
+        result.meta.page, result.meta.total_pages
+    );
     println!("   Items: {}", result.data.len());
 
     Ok(())
 }
 
 /// Simulate GraphQL-style pagination
-async fn graphql_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn graphql_pagination_pattern(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("🔍 GraphQL Pagination Pattern\n");
 
     // Simulate cursor-based pagination query
@@ -125,13 +143,17 @@ async fn graphql_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<()
     println!("     pageInfo {{ hasNextPage, hasPreviousPage }}");
     println!("   }}");
 
-    let result = graphql_get_accounts(ledger, GraphQLAccountsQuery {
-        first: Some(5),
-        after: None,
-        filter: Some(GraphQLAccountFilter {
-            account_type: Some("EXPENSE".to_string()),
-        }),
-    }).await?;
+    let result = graphql_get_accounts(
+        ledger,
+        GraphQLAccountsQuery {
+            first: Some(5),
+            after: None,
+            filter: Some(GraphQLAccountFilter {
+                account_type: Some("EXPENSE".to_string()),
+            }),
+        },
+    )
+    .await?;
 
     println!("\n📤 GraphQL Response:");
     println!("{}", serde_json::to_string_pretty(&result)?);
@@ -140,7 +162,9 @@ async fn graphql_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<()
 }
 
 /// Simulate infinite scroll pagination
-async fn infinite_scroll_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn infinite_scroll_pattern(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("♾️  Infinite Scroll Pattern\n");
 
     let mut loaded_items = 0;
@@ -149,28 +173,32 @@ async fn infinite_scroll_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), B
     // Simulate loading 3 batches
     for batch in 1..=3 {
         println!("📱 Loading batch {} (infinite scroll):", batch);
-        
+
         let pagination = PaginationParams::new(batch, batch_size)?;
-        let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+        let result = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?;
         let result = result.to_paginated_response();
-        
+
         loaded_items += result.items.len();
-        
-        println!("   ↓ Loaded {} items (total: {}/{})", 
-                 result.items.len(), 
-                 loaded_items, 
-                 result.total_count);
-        
+
+        println!(
+            "   ↓ Loaded {} items (total: {}/{})",
+            result.items.len(),
+            loaded_items,
+            result.total_count
+        );
+
         // Show last 2 items in this batch
         for account in result.items.iter().rev().take(2).rev() {
             println!("     • {} - {}", account.id, account.name);
         }
-        
+
         if !result.has_next {
             println!("   ✅ All items loaded!");
             break;
         }
-        
+
         println!("   📜 Scroll for more...\n");
     }
 
@@ -178,7 +206,9 @@ async fn infinite_scroll_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), B
 }
 
 /// Simulate data table pagination with sorting and filtering
-async fn table_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn table_pagination_pattern(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("📊 Data Table Pagination\n");
 
     // Simulate table request with sorting and filtering
@@ -195,8 +225,14 @@ async fn table_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), 
     };
 
     println!("🗂️  Table Request:");
-    println!("   Page: {}, Size: {}", table_request.page, table_request.page_size);
-    println!("   Sort: {} {}", table_request.sort_by, table_request.sort_order);
+    println!(
+        "   Page: {}, Size: {}",
+        table_request.page, table_request.page_size
+    );
+    println!(
+        "   Sort: {} {}",
+        table_request.sort_by, table_request.sort_order
+    );
     println!("   Filters: {:?}", table_request.filters);
 
     let result = process_table_request(ledger, table_request).await?;
@@ -205,20 +241,24 @@ async fn table_pagination_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), 
     println!("┌─────────┬──────────────────────────────┬─────────────┐");
     println!("│ Account │ Name                         │ Type        │");
     println!("├─────────┼──────────────────────────────┼─────────────┤");
-    
+
     for account in &result.data {
-        println!("│ {:7} │ {:28} │ {:11} │", 
-                 account.id, 
-                 &account.name[..std::cmp::min(account.name.len(), 28)],
-                 format!("{:?}", account.account_type));
+        println!(
+            "│ {:7} │ {:28} │ {:11} │",
+            account.id,
+            &account.name[..std::cmp::min(account.name.len(), 28)],
+            format!("{:?}", account.account_type)
+        );
     }
-    
+
     println!("└─────────┴──────────────────────────────┴─────────────┘");
-    println!("Showing {} of {} items | Page {} of {}", 
-             result.data.len(),
-             result.pagination.total_items,
-             result.pagination.current_page,
-             result.pagination.total_pages);
+    println!(
+        "Showing {} of {} items | Page {} of {}",
+        result.data.len(),
+        result.pagination.total_items,
+        result.pagination.current_page,
+        result.pagination.total_pages
+    );
 
     Ok(())
 }
@@ -328,8 +368,8 @@ struct TablePaginationInfo {
 // API Implementation Functions
 
 async fn api_get_accounts(
-    ledger: &Ledger<MemoryStorage>, 
-    query: ApiAccountsQuery
+    ledger: &Ledger<MemoryStorage>,
+    query: ApiAccountsQuery,
 ) -> Result<ApiAccountsResponse, Box<dyn std::error::Error>> {
     let page = query.page.unwrap_or(1);
     let limit = query.limit.unwrap_or(20);
@@ -344,18 +384,26 @@ async fn api_get_accounts(
             "expense" => AccountType::Expense,
             _ => return Err("Invalid account type".into()),
         };
-        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+            .await?
     } else {
-        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?
     };
     let result = result.to_paginated_response();
 
-    let data = result.items.into_iter().map(|account| AccountDto {
-        id: account.id,
-        name: account.name,
-        account_type: format!("{:?}", account.account_type).to_lowercase(),
-        balance: account.balance.to_string(),
-    }).collect();
+    let data = result
+        .items
+        .into_iter()
+        .map(|account| AccountDto {
+            id: account.id,
+            name: account.name,
+            account_type: format!("{:?}", account.account_type).to_lowercase(),
+            balance: account.balance.to_string(),
+        })
+        .collect();
 
     Ok(ApiAccountsResponse {
         data,
@@ -376,9 +424,9 @@ async fn graphql_get_accounts(
 ) -> Result<GraphQLAccountsResponse, Box<dyn std::error::Error>> {
     let first = query.first.unwrap_or(10);
     let page = 1; // In a real implementation, you'd decode the cursor
-    
+
     let pagination = PaginationParams::new(page, first)?;
-    
+
     let result = if let Some(filter) = query.filter {
         if let Some(type_str) = filter.account_type {
             let account_type = match type_str.as_str() {
@@ -389,23 +437,33 @@ async fn graphql_get_accounts(
                 "EXPENSE" => AccountType::Expense,
                 _ => return Err("Invalid account type".into()),
             };
-            ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
+            ledger
+                .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+                .await?
         } else {
-            ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
+            ledger
+                .list_accounts(PaginationOption::Paginated(pagination))
+                .await?
         }
     } else {
-        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?
     };
     let result = result.to_paginated_response();
 
-    let edges = result.items.into_iter().map(|account| GraphQLAccountEdge {
-        node: AccountDto {
-            id: account.id,
-            name: account.name,
-            account_type: format!("{:?}", account.account_type),
-            balance: account.balance.to_string(),
-        }
-    }).collect();
+    let edges = result
+        .items
+        .into_iter()
+        .map(|account| GraphQLAccountEdge {
+            node: AccountDto {
+                id: account.id,
+                name: account.name,
+                account_type: format!("{:?}", account.account_type),
+                balance: account.balance.to_string(),
+            },
+        })
+        .collect();
 
     Ok(GraphQLAccountsResponse {
         data: GraphQLAccountsData {
@@ -435,9 +493,13 @@ async fn process_table_request(
             "expense" => AccountType::Expense,
             _ => return Err("Invalid account type filter".into()),
         };
-        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+            .await?
     } else {
-        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?
     };
     let result = result.to_paginated_response();
 

--- a/examples/api_pagination_patterns.rs
+++ b/examples/api_pagination_patterns.rs
@@ -4,7 +4,7 @@
 //! handle query parameters, and build efficient data access patterns.
 
 use accounting_core::{
-    AccountType, Ledger, PaginationParams, Account,
+    Account, AccountType, Ledger, PaginationOption, PaginationParams,
     utils::memory_storage::MemoryStorage,
 };
 use serde::{Deserialize, Serialize};
@@ -341,9 +341,9 @@ async fn api_get_accounts(
             "expense" => AccountType::Expense,
             _ => return Err("Invalid account type".into()),
         };
-        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
     } else {
-        ledger.list_accounts_paginated(pagination).await?
+        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
 
     let data = result.items.into_iter().map(|account| AccountDto {
@@ -385,12 +385,12 @@ async fn graphql_get_accounts(
                 "EXPENSE" => AccountType::Expense,
                 _ => return Err("Invalid account type".into()),
             };
-            ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+            ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
         } else {
-            ledger.list_accounts_paginated(pagination).await?
+            ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
         }
     } else {
-        ledger.list_accounts_paginated(pagination).await?
+        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
 
     let edges = result.items.into_iter().map(|account| GraphQLAccountEdge {
@@ -430,9 +430,9 @@ async fn process_table_request(
             "expense" => AccountType::Expense,
             _ => return Err("Invalid account type filter".into()),
         };
-        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
     } else {
-        ledger.list_accounts_paginated(pagination).await?
+        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
 
     // Note: In a real implementation, you'd handle sorting at the storage level

--- a/examples/api_pagination_patterns.rs
+++ b/examples/api_pagination_patterns.rs
@@ -151,7 +151,8 @@ async fn infinite_scroll_pattern(ledger: &Ledger<MemoryStorage>) -> Result<(), B
         println!("📱 Loading batch {} (infinite scroll):", batch);
         
         let pagination = PaginationParams::new(batch, batch_size)?;
-        let result = ledger.list_accounts_paginated(pagination).await?;
+        let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+        let result = result.to_paginated_response();
         
         loaded_items += result.items.len();
         
@@ -345,6 +346,7 @@ async fn api_get_accounts(
     } else {
         ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
+    let result = result.to_paginated_response();
 
     let data = result.items.into_iter().map(|account| AccountDto {
         id: account.id,
@@ -392,6 +394,7 @@ async fn graphql_get_accounts(
     } else {
         ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
+    let result = result.to_paginated_response();
 
     let edges = result.items.into_iter().map(|account| GraphQLAccountEdge {
         node: AccountDto {
@@ -434,6 +437,7 @@ async fn process_table_request(
     } else {
         ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
+    let result = result.to_paginated_response();
 
     // Note: In a real implementation, you'd handle sorting at the storage level
     // For this example, we'll just use the results as-is since they're already sorted by ID

--- a/examples/api_pagination_patterns.rs
+++ b/examples/api_pagination_patterns.rs
@@ -258,6 +258,7 @@ struct ApiPaginationMeta {
 
 // GraphQL structures
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct GraphQLAccountsQuery {
     first: Option<u32>,
     after: Option<String>,
@@ -316,6 +317,7 @@ struct TableResponse {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct TablePaginationInfo {
     current_page: u32,
     total_pages: u32,

--- a/examples/pagination_demo.rs
+++ b/examples/pagination_demo.rs
@@ -8,8 +8,8 @@
 //! - Error handling
 
 use accounting_core::{
-    AccountType, Entry, EntryType, Ledger, PaginationOption, PaginationParams, Transaction,
-    utils::memory_storage::MemoryStorage,
+    utils::memory_storage::MemoryStorage, AccountType, Entry, EntryType, Ledger, PaginationOption,
+    PaginationParams, Transaction,
 };
 use bigdecimal::BigDecimal;
 use chrono::NaiveDate;
@@ -68,7 +68,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Setup sample data for demonstrations
-async fn setup_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn setup_sample_data(
+    ledger: &mut Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("Setting up sample data...");
 
     // Create various account types
@@ -77,30 +79,51 @@ async fn setup_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box
         ("bank", "Bank Account", AccountType::Asset),
         ("inventory", "Inventory", AccountType::Asset),
         ("equipment", "Equipment", AccountType::Asset),
-        ("accounts_receivable", "Accounts Receivable", AccountType::Asset),
+        (
+            "accounts_receivable",
+            "Accounts Receivable",
+            AccountType::Asset,
+        ),
         ("prepaid_expenses", "Prepaid Expenses", AccountType::Asset),
-        ("accounts_payable", "Accounts Payable", AccountType::Liability),
+        (
+            "accounts_payable",
+            "Accounts Payable",
+            AccountType::Liability,
+        ),
         ("loan_payable", "Loan Payable", AccountType::Liability),
-        ("accrued_expenses", "Accrued Expenses", AccountType::Liability),
+        (
+            "accrued_expenses",
+            "Accrued Expenses",
+            AccountType::Liability,
+        ),
         ("owner_equity", "Owner's Equity", AccountType::Equity),
-        ("retained_earnings", "Retained Earnings", AccountType::Equity),
+        (
+            "retained_earnings",
+            "Retained Earnings",
+            AccountType::Equity,
+        ),
         ("sales_revenue", "Sales Revenue", AccountType::Income),
         ("service_revenue", "Service Revenue", AccountType::Income),
         ("interest_income", "Interest Income", AccountType::Income),
         ("rent_expense", "Rent Expense", AccountType::Expense),
-        ("utilities_expense", "Utilities Expense", AccountType::Expense),
+        (
+            "utilities_expense",
+            "Utilities Expense",
+            AccountType::Expense,
+        ),
         ("salary_expense", "Salary Expense", AccountType::Expense),
-        ("marketing_expense", "Marketing Expense", AccountType::Expense),
+        (
+            "marketing_expense",
+            "Marketing Expense",
+            AccountType::Expense,
+        ),
     ];
 
     // Create accounts
     for (id, name, account_type) in account_data {
-        ledger.create_account(
-            id.to_string(),
-            name.to_string(),
-            account_type,
-            None,
-        ).await?;
+        ledger
+            .create_account(id.to_string(), name.to_string(), account_type, None)
+            .await?;
     }
 
     // Create sample transactions
@@ -176,17 +199,24 @@ async fn setup_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box
 }
 
 /// Example 1: Basic account pagination
-async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn basic_account_pagination(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Get first page with default settings (page 1, 50 items per page)
     let pagination = PaginationParams::default();
-    let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+    let result = ledger
+        .list_accounts(PaginationOption::Paginated(pagination))
+        .await?;
     let result = result.to_paginated_response();
 
     println!("📊 First page (default settings):");
     println!("   Items: {}/{}", result.items.len(), result.total_count);
     println!("   Page: {} of {}", result.page, result.total_pages);
-    println!("   Has next: {}, Has previous: {}", result.has_next, result.has_previous);
-    
+    println!(
+        "   Has next: {}, Has previous: {}",
+        result.has_next, result.has_previous
+    );
+
     // Show first 3 accounts
     for account in result.items.iter().take(3) {
         println!("   • {} - {}", account.id, account.name);
@@ -197,43 +227,57 @@ async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
 
     // Get first page with smaller page size
     let pagination = PaginationParams::new(1, 5)?;
-    let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+    let result = ledger
+        .list_accounts(PaginationOption::Paginated(pagination))
+        .await?;
     let result = result.to_paginated_response();
 
     println!("\n📊 First page (5 items per page):");
     println!("   Items: {}/{}", result.items.len(), result.total_count);
     println!("   Page: {} of {}", result.page, result.total_pages);
-    
+
     for account in &result.items {
-        println!("   • {} - {} ({:?})", account.id, account.name, account.account_type);
+        println!(
+            "   • {} - {} ({:?})",
+            account.id, account.name, account.account_type
+        );
     }
 
     Ok(())
 }
 
 /// Example 2: Paginated accounts by type
-async fn paginated_accounts_by_type(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn paginated_accounts_by_type(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Get only Asset accounts with pagination
     let pagination = PaginationParams::new(1, 10)?;
-    let result = ledger.list_accounts_by_type(AccountType::Asset, PaginationOption::Paginated(pagination)).await?;
+    let result = ledger
+        .list_accounts_by_type(AccountType::Asset, PaginationOption::Paginated(pagination))
+        .await?;
     let result = result.to_paginated_response();
 
     println!("📊 Asset accounts (page 1):");
     println!("   Total assets: {}", result.total_count);
     println!("   Showing: {} items", result.items.len());
-    
+
     for account in &result.items {
         println!("   💰 {} - {}", account.id, account.name);
     }
 
     // Get Revenue accounts
     let pagination2 = PaginationParams::new(1, 10)?;
-    let result = ledger.list_accounts_by_type(AccountType::Income, PaginationOption::Paginated(pagination2)).await?;
+    let result = ledger
+        .list_accounts_by_type(
+            AccountType::Income,
+            PaginationOption::Paginated(pagination2),
+        )
+        .await?;
     let result = result.to_paginated_response();
-    
+
     println!("\n📊 Income accounts:");
     println!("   Total income accounts: {}", result.total_count);
-    
+
     for account in &result.items {
         println!("   💵 {} - {}", account.id, account.name);
     }
@@ -242,20 +286,24 @@ async fn paginated_accounts_by_type(ledger: &Ledger<MemoryStorage>) -> Result<()
 }
 
 /// Example 3: Basic transaction pagination
-async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn basic_transaction_pagination(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Get first page of transactions (10 per page)
     let pagination = PaginationParams::new(1, 10)?;
-    let result = ledger.get_transactions(None, None, PaginationOption::Paginated(pagination)).await?;
+    let result = ledger
+        .get_transactions(None, None, PaginationOption::Paginated(pagination))
+        .await?;
     let result = result.to_paginated_response();
 
     println!("📊 Recent transactions (page 1 of {}):", result.total_pages);
     println!("   Total transactions: {}", result.total_count);
-    
+
     for transaction in &result.items {
-        println!("   📝 {} - {} ({})", 
-                 transaction.id, 
-                 transaction.description, 
-                 transaction.date);
+        println!(
+            "   📝 {} - {} ({})",
+            transaction.id, transaction.description, transaction.date
+        );
         println!("      Amount: ${}", transaction.total_debits());
     }
 
@@ -263,9 +311,11 @@ async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<
     if result.has_next {
         println!("\n📊 Getting second page...");
         let pagination = PaginationParams::new(2, 10)?;
-        let result = ledger.get_transactions(None, None, PaginationOption::Paginated(pagination)).await?;
+        let result = ledger
+            .get_transactions(None, None, PaginationOption::Paginated(pagination))
+            .await?;
         let result = result.to_paginated_response();
-        
+
         println!("   Page 2 - {} transactions:", result.items.len());
         for transaction in result.items.iter().take(3) {
             println!("   📝 {} - {}", transaction.id, transaction.description);
@@ -279,73 +329,89 @@ async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<
 }
 
 /// Example 4: Account-specific transaction pagination
-async fn account_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn account_transaction_pagination(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Get transactions for the cash account
     let pagination = PaginationParams::new(1, 5)?;
-    let result = ledger.get_account_transactions(
-        "cash", 
-        None, 
-        None, 
-        PaginationOption::Paginated(pagination)
-    ).await?;
+    let result = ledger
+        .get_account_transactions("cash", None, None, PaginationOption::Paginated(pagination))
+        .await?;
     let result = result.to_paginated_response();
 
     println!("📊 Cash account transactions:");
     println!("   Total: {} transactions", result.total_count);
     println!("   Page: {} of {}", result.page, result.total_pages);
-    
+
     for transaction in &result.items {
         // Find the cash entry in this transaction
-        let cash_entry = transaction.entries.iter()
+        let cash_entry = transaction
+            .entries
+            .iter()
             .find(|e| e.account_id == "cash")
             .unwrap();
-        
+
         let direction = match cash_entry.entry_type {
             EntryType::Debit => "💰 Received",
             EntryType::Credit => "💸 Paid",
         };
-        
-        println!("   {} ${} - {} ({})", 
-                 direction, 
-                 cash_entry.amount, 
-                 transaction.description,
-                 transaction.date);
+
+        println!(
+            "   {} ${} - {} ({})",
+            direction, cash_entry.amount, transaction.description, transaction.date
+        );
     }
 
     Ok(())
 }
 
 /// Example 5: Date-filtered transaction pagination
-async fn date_filtered_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn date_filtered_pagination(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Get transactions for the first week of January 2024
     let start_date = NaiveDate::from_ymd_opt(2024, 1, 1);
     let end_date = NaiveDate::from_ymd_opt(2024, 1, 7);
     let pagination = PaginationParams::new(1, 20)?;
-    
-    let result = ledger.get_transactions(start_date, end_date, PaginationOption::Paginated(pagination)).await?;
+
+    let result = ledger
+        .get_transactions(
+            start_date,
+            end_date,
+            PaginationOption::Paginated(pagination),
+        )
+        .await?;
     let paginated_result = result.to_paginated_response();
 
     println!("📊 Transactions from Jan 1-7, 2024:");
     println!("   Found: {} transactions", paginated_result.total_count);
-    
+
     for transaction in &paginated_result.items {
-        println!("   📅 {} - {} (${:.2})", 
-                 transaction.date,
-                 transaction.description, 
-                 transaction.total_debits());
+        println!(
+            "   📅 {} - {} (${:.2})",
+            transaction.date,
+            transaction.description,
+            transaction.total_debits()
+        );
     }
 
     // Get transactions for mid-January
     let start_date = NaiveDate::from_ymd_opt(2024, 1, 15);
     let end_date = NaiveDate::from_ymd_opt(2024, 1, 20);
     let pagination2 = PaginationParams::new(1, 20)?;
-    
-    let result = ledger.get_transactions(start_date, end_date, PaginationOption::Paginated(pagination2)).await?;
+
+    let result = ledger
+        .get_transactions(
+            start_date,
+            end_date,
+            PaginationOption::Paginated(pagination2),
+        )
+        .await?;
     let paginated_result = result.to_paginated_response();
-    
+
     println!("\n📊 Transactions from Jan 15-20, 2024:");
     println!("   Found: {} transactions", paginated_result.total_count);
-    
+
     for transaction in &paginated_result.items {
         println!("   📅 {} - {}", transaction.date, transaction.description);
     }
@@ -354,43 +420,51 @@ async fn date_filtered_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
 }
 
 /// Example 6: Pagination navigation helpers
-async fn pagination_navigation_helpers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn pagination_navigation_helpers(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let page_size = 8;
     let mut current_page = 1;
 
     println!("🧭 Navigation through all account pages:");
-    
+
     loop {
         let pagination = PaginationParams::new(current_page, page_size)?;
-        let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+        let result = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?;
         let paginated_result = result.to_paginated_response();
-        
-        println!("\n   📄 Page {} of {} ({} items):", 
-                 paginated_result.page, 
-                 paginated_result.total_pages, 
-                 paginated_result.items.len());
-        
+
+        println!(
+            "\n   📄 Page {} of {} ({} items):",
+            paginated_result.page,
+            paginated_result.total_pages,
+            paginated_result.items.len()
+        );
+
         for (i, account) in paginated_result.items.iter().enumerate() {
-            println!("      {}. {} - {}", 
-                     (current_page - 1) * page_size + i as u32 + 1,
-                     account.id, 
-                     account.name);
+            println!(
+                "      {}. {} - {}",
+                (current_page - 1) * page_size + i as u32 + 1,
+                account.id,
+                account.name
+            );
         }
-        
+
         // Navigation info
         let nav_info = build_navigation_info(&paginated_result);
         println!("   🔗 Navigation: {}", nav_info);
-        
+
         // Break after showing 2 pages as example
         if current_page >= 2 {
             println!("   (Showing first 2 pages as example...)");
             break;
         }
-        
+
         if !paginated_result.has_next {
             break;
         }
-        
+
         current_page += 1;
     }
 
@@ -422,9 +496,16 @@ async fn error_handling_examples() -> Result<(), Box<dyn std::error::Error>> {
     // Test valid parameters
     match PaginationParams::new(5, 25) {
         Ok(params) => {
-            println!("   ✅ Valid params: page={}, size={}", params.page, params.page_size);
-            println!("      Offset: {}, Limit: {}", params.offset(), params.limit());
-        },
+            println!(
+                "   ✅ Valid params: page={}, size={}",
+                params.page, params.page_size
+            );
+            println!(
+                "      Offset: {}, Limit: {}",
+                params.offset(),
+                params.limit()
+            );
+        }
         Err(e) => println!("   ❌ Unexpected error: {}", e),
     }
 
@@ -432,25 +513,33 @@ async fn error_handling_examples() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Example 8: Simple pagination UI helper
-async fn pagination_ui_helper(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn pagination_ui_helper(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("🖥️  Pagination UI Helper Example:");
 
     // Simulate a UI request for page 2 of transactions
     let page_request = 2;
     let page_size = 6;
-    
+
     let pagination = PaginationParams::new(page_request, page_size)?;
-    let result = ledger.get_transactions(None, None, PaginationOption::Paginated(pagination)).await?;
+    let result = ledger
+        .get_transactions(None, None, PaginationOption::Paginated(pagination))
+        .await?;
     let result = result.to_paginated_response();
 
     // Build UI-friendly response
     let ui_response = PaginationUIResponse {
-        items: result.items.iter().map(|t| TransactionSummary {
-            id: t.id.clone(),
-            date: t.date,
-            description: t.description.clone(),
-            amount: t.total_debits(),
-        }).collect(),
+        items: result
+            .items
+            .iter()
+            .map(|t| TransactionSummary {
+                id: t.id.clone(),
+                date: t.date,
+                description: t.description.clone(),
+                amount: t.total_debits(),
+            })
+            .collect(),
         pagination_info: PaginationInfo {
             current_page: result.page,
             total_pages: result.total_pages,
@@ -459,24 +548,23 @@ async fn pagination_ui_helper(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<
             has_previous: result.has_previous,
             has_next: result.has_next,
             start_item: ((result.page - 1) * result.page_size) + 1,
-            end_item: std::cmp::min(
-                result.page * result.page_size,
-                result.total_count,
-            ),
+            end_item: std::cmp::min(result.page * result.page_size, result.total_count),
         },
     };
 
     println!("   📊 Transaction List (UI Format):");
-    println!("   Showing items {}-{} of {}", 
-             ui_response.pagination_info.start_item,
-             ui_response.pagination_info.end_item,
-             ui_response.pagination_info.total_items);
+    println!(
+        "   Showing items {}-{} of {}",
+        ui_response.pagination_info.start_item,
+        ui_response.pagination_info.end_item,
+        ui_response.pagination_info.total_items
+    );
 
     for item in &ui_response.items {
-        println!("   • {} - {} (${:.2})", 
-                 item.date, 
-                 item.description, 
-                 item.amount);
+        println!(
+            "   • {} - {} (${:.2})",
+            item.date, item.description, item.amount
+        );
     }
 
     // Generate pagination controls
@@ -519,42 +607,46 @@ struct PaginationUIResponse {
 /// Build navigation information string
 fn build_navigation_info<T>(result: &accounting_core::PaginatedResponse<T>) -> String {
     let mut parts = Vec::new();
-    
+
     if result.has_previous {
         parts.push("← Prev".to_string());
     }
-    
+
     parts.push(format!("Page {} of {}", result.page, result.total_pages));
-    
+
     if result.has_next {
         parts.push("Next →".to_string());
     }
-    
+
     parts.join(" | ")
 }
 
 /// Generate pagination controls for UI
 fn generate_pagination_controls(info: &PaginationInfo) -> String {
     let mut controls = Vec::new();
-    
+
     // Previous button
     if info.has_previous {
         controls.push("[← Previous]".to_string());
     } else {
         controls.push("[Previous]".to_string());
     }
-    
+
     // Page numbers (show current and adjacent)
-    let start_page = if info.current_page > 2 { info.current_page - 2 } else { 1 };
+    let start_page = if info.current_page > 2 {
+        info.current_page - 2
+    } else {
+        1
+    };
     let end_page = std::cmp::min(start_page + 4, info.total_pages);
-    
+
     if start_page > 1 {
         controls.push("[1]".to_string());
         if start_page > 2 {
             controls.push("...".to_string());
         }
     }
-    
+
     for page in start_page..=end_page {
         if page == info.current_page {
             controls.push(format!("[{}]", page));
@@ -562,20 +654,20 @@ fn generate_pagination_controls(info: &PaginationInfo) -> String {
             controls.push(format!("{}", page));
         }
     }
-    
+
     if end_page < info.total_pages {
         if end_page < info.total_pages - 1 {
             controls.push("...".to_string());
         }
         controls.push(format!("[{}]", info.total_pages));
     }
-    
+
     // Next button
     if info.has_next {
         controls.push("[Next →]".to_string());
     } else {
         controls.push("[Next]".to_string());
     }
-    
+
     controls.join(" ")
 }

--- a/examples/pagination_demo.rs
+++ b/examples/pagination_demo.rs
@@ -1,0 +1,568 @@
+//! Comprehensive examples of using paginated responses for accounts and transactions
+//!
+//! This example demonstrates:
+//! - Basic pagination setup
+//! - Navigating through pages
+//! - Filtering with pagination
+//! - Building pagination UI helpers
+//! - Error handling
+
+use accounting_core::{
+    AccountType, Entry, EntryType, Ledger, PaginationParams, Transaction,
+    utils::memory_storage::MemoryStorage,
+};
+use bigdecimal::BigDecimal;
+use chrono::NaiveDate;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔍 Accounting Core - Pagination Examples\n");
+
+    // Create a ledger with in-memory storage
+    let storage = MemoryStorage::new();
+    let mut ledger = Ledger::new(storage);
+
+    // Setup sample data
+    setup_sample_data(&mut ledger).await?;
+
+    // Example 1: Basic account pagination
+    println!("📄 Example 1: Basic Account Pagination");
+    basic_account_pagination(&ledger).await?;
+    println!();
+
+    // Example 2: Paginated accounts by type
+    println!("🏢 Example 2: Paginated Accounts by Type");
+    paginated_accounts_by_type(&ledger).await?;
+    println!();
+
+    // Example 3: Basic transaction pagination
+    println!("💸 Example 3: Basic Transaction Pagination");
+    basic_transaction_pagination(&ledger).await?;
+    println!();
+
+    // Example 4: Account-specific transaction pagination
+    println!("🏦 Example 4: Account-Specific Transaction Pagination");
+    account_transaction_pagination(&ledger).await?;
+    println!();
+
+    // Example 5: Date-filtered transaction pagination
+    println!("📅 Example 5: Date-Filtered Transaction Pagination");
+    date_filtered_pagination(&ledger).await?;
+    println!();
+
+    // Example 6: Pagination navigation helpers
+    println!("🧭 Example 6: Pagination Navigation Helpers");
+    pagination_navigation_helpers(&ledger).await?;
+    println!();
+
+    // Example 7: Error handling and validation
+    println!("⚠️  Example 7: Error Handling and Validation");
+    error_handling_examples().await?;
+    println!();
+
+    // Example 8: Building a simple pagination UI
+    println!("🖥️  Example 8: Simple Pagination UI Helper");
+    pagination_ui_helper(&ledger).await?;
+
+    Ok(())
+}
+
+/// Setup sample data for demonstrations
+async fn setup_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("Setting up sample data...");
+
+    // Create various account types
+    let account_data = [
+        ("cash", "Cash", AccountType::Asset),
+        ("bank", "Bank Account", AccountType::Asset),
+        ("inventory", "Inventory", AccountType::Asset),
+        ("equipment", "Equipment", AccountType::Asset),
+        ("accounts_receivable", "Accounts Receivable", AccountType::Asset),
+        ("prepaid_expenses", "Prepaid Expenses", AccountType::Asset),
+        ("accounts_payable", "Accounts Payable", AccountType::Liability),
+        ("loan_payable", "Loan Payable", AccountType::Liability),
+        ("accrued_expenses", "Accrued Expenses", AccountType::Liability),
+        ("owner_equity", "Owner's Equity", AccountType::Equity),
+        ("retained_earnings", "Retained Earnings", AccountType::Equity),
+        ("sales_revenue", "Sales Revenue", AccountType::Income),
+        ("service_revenue", "Service Revenue", AccountType::Income),
+        ("interest_income", "Interest Income", AccountType::Income),
+        ("rent_expense", "Rent Expense", AccountType::Expense),
+        ("utilities_expense", "Utilities Expense", AccountType::Expense),
+        ("salary_expense", "Salary Expense", AccountType::Expense),
+        ("marketing_expense", "Marketing Expense", AccountType::Expense),
+    ];
+
+    // Create accounts
+    for (id, name, account_type) in account_data {
+        ledger.create_account(
+            id.to_string(),
+            name.to_string(),
+            account_type,
+            None,
+        ).await?;
+    }
+
+    // Create sample transactions
+    for i in 1..=30 {
+        let mut transaction = Transaction::new(
+            format!("txn_{:03}", i),
+            NaiveDate::from_ymd_opt(2024, 1, (i % 28) + 1).unwrap(),
+            format!("Sample transaction {}", i),
+            Some(format!("REF{:03}", i)),
+        );
+
+        // Create various transaction patterns
+        match i % 4 {
+            0 => {
+                // Sales transaction: Debit Cash, Credit Sales Revenue
+                transaction.add_entry(Entry::debit(
+                    "cash".to_string(),
+                    BigDecimal::from(1000 + i * 10),
+                    Some("Cash received".to_string()),
+                ));
+                transaction.add_entry(Entry::credit(
+                    "sales_revenue".to_string(),
+                    BigDecimal::from(1000 + i * 10),
+                    Some("Sales revenue".to_string()),
+                ));
+            }
+            1 => {
+                // Expense payment: Debit Rent Expense, Credit Cash
+                transaction.add_entry(Entry::debit(
+                    "rent_expense".to_string(),
+                    BigDecimal::from(500 + i * 5),
+                    Some("Rent payment".to_string()),
+                ));
+                transaction.add_entry(Entry::credit(
+                    "cash".to_string(),
+                    BigDecimal::from(500 + i * 5),
+                    Some("Cash payment".to_string()),
+                ));
+            }
+            2 => {
+                // Equipment purchase: Debit Equipment, Credit Cash
+                transaction.add_entry(Entry::debit(
+                    "equipment".to_string(),
+                    BigDecimal::from(2000 + i * 20),
+                    Some("Equipment purchase".to_string()),
+                ));
+                transaction.add_entry(Entry::credit(
+                    "cash".to_string(),
+                    BigDecimal::from(2000 + i * 20),
+                    Some("Cash payment".to_string()),
+                ));
+            }
+            _ => {
+                // Service revenue: Debit Accounts Receivable, Credit Service Revenue
+                transaction.add_entry(Entry::debit(
+                    "accounts_receivable".to_string(),
+                    BigDecimal::from(800 + i * 8),
+                    Some("Service rendered".to_string()),
+                ));
+                transaction.add_entry(Entry::credit(
+                    "service_revenue".to_string(),
+                    BigDecimal::from(800 + i * 8),
+                    Some("Service revenue".to_string()),
+                ));
+            }
+        }
+
+        ledger.record_transaction(transaction).await?;
+    }
+
+    println!("✅ Sample data created: 18 accounts, 30 transactions\n");
+    Ok(())
+}
+
+/// Example 1: Basic account pagination
+async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Get first page with default settings (page 1, 50 items per page)
+    let pagination = PaginationParams::default();
+    let result = ledger.list_accounts_paginated(pagination).await?;
+
+    println!("📊 First page (default settings):");
+    println!("   Items: {}/{}", result.items.len(), result.total_count);
+    println!("   Page: {} of {}", result.page, result.total_pages);
+    println!("   Has next: {}, Has previous: {}", result.has_next, result.has_previous);
+    
+    // Show first 3 accounts
+    for account in result.items.iter().take(3) {
+        println!("   • {} - {}", account.id, account.name);
+    }
+    if result.items.len() > 3 {
+        println!("   ... and {} more", result.items.len() - 3);
+    }
+
+    // Get first page with smaller page size
+    let pagination = PaginationParams::new(1, 5)?;
+    let result = ledger.list_accounts_paginated(pagination).await?;
+
+    println!("\n📊 First page (5 items per page):");
+    println!("   Items: {}/{}", result.items.len(), result.total_count);
+    println!("   Page: {} of {}", result.page, result.total_pages);
+    
+    for account in &result.items {
+        println!("   • {} - {} ({})", account.id, account.name, format!("{:?}", account.account_type));
+    }
+
+    Ok(())
+}
+
+/// Example 2: Paginated accounts by type
+async fn paginated_accounts_by_type(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Get only Asset accounts with pagination
+    let pagination = PaginationParams::new(1, 10)?;
+    let result = ledger.list_accounts_by_type_paginated(AccountType::Asset, pagination).await?;
+
+    println!("📊 Asset accounts (page 1):");
+    println!("   Total assets: {}", result.total_count);
+    println!("   Showing: {} items", result.items.len());
+    
+    for account in &result.items {
+        println!("   💰 {} - {}", account.id, account.name);
+    }
+
+    // Get Revenue accounts
+    let pagination2 = PaginationParams::new(1, 10)?;
+    let result = ledger.list_accounts_by_type_paginated(AccountType::Income, pagination2).await?;
+    
+    println!("\n📊 Income accounts:");
+    println!("   Total income accounts: {}", result.total_count);
+    
+    for account in &result.items {
+        println!("   💵 {} - {}", account.id, account.name);
+    }
+
+    Ok(())
+}
+
+/// Example 3: Basic transaction pagination
+async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Get first page of transactions (10 per page)
+    let pagination = PaginationParams::new(1, 10)?;
+    let result = ledger.get_transactions_paginated(None, None, pagination).await?;
+
+    println!("📊 Recent transactions (page 1 of {}):", result.total_pages);
+    println!("   Total transactions: {}", result.total_count);
+    
+    for transaction in &result.items {
+        println!("   📝 {} - {} ({})", 
+                 transaction.id, 
+                 transaction.description, 
+                 transaction.date);
+        println!("      Amount: ${}", transaction.total_debits());
+    }
+
+    // Get second page
+    if result.has_next {
+        println!("\n📊 Getting second page...");
+        let pagination = PaginationParams::new(2, 10)?;
+        let result = ledger.get_transactions_paginated(None, None, pagination).await?;
+        
+        println!("   Page 2 - {} transactions:", result.items.len());
+        for transaction in result.items.iter().take(3) {
+            println!("   📝 {} - {}", transaction.id, transaction.description);
+        }
+        if result.items.len() > 3 {
+            println!("   ... and {} more", result.items.len() - 3);
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 4: Account-specific transaction pagination
+async fn account_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Get transactions for the cash account
+    let pagination = PaginationParams::new(1, 5)?;
+    let result = ledger.get_account_transactions_paginated(
+        "cash", 
+        None, 
+        None, 
+        pagination
+    ).await?;
+
+    println!("📊 Cash account transactions:");
+    println!("   Total: {} transactions", result.total_count);
+    println!("   Page: {} of {}", result.page, result.total_pages);
+    
+    for transaction in &result.items {
+        // Find the cash entry in this transaction
+        let cash_entry = transaction.entries.iter()
+            .find(|e| e.account_id == "cash")
+            .unwrap();
+        
+        let direction = match cash_entry.entry_type {
+            EntryType::Debit => "💰 Received",
+            EntryType::Credit => "💸 Paid",
+        };
+        
+        println!("   {} ${} - {} ({})", 
+                 direction, 
+                 cash_entry.amount, 
+                 transaction.description,
+                 transaction.date);
+    }
+
+    Ok(())
+}
+
+/// Example 5: Date-filtered transaction pagination
+async fn date_filtered_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Get transactions for the first week of January 2024
+    let start_date = NaiveDate::from_ymd_opt(2024, 1, 1);
+    let end_date = NaiveDate::from_ymd_opt(2024, 1, 7);
+    let pagination = PaginationParams::new(1, 20)?;
+    
+    let result = ledger.get_transactions_paginated(start_date, end_date, pagination).await?;
+
+    println!("📊 Transactions from Jan 1-7, 2024:");
+    println!("   Found: {} transactions", result.total_count);
+    
+    for transaction in &result.items {
+        println!("   📅 {} - {} (${:.2})", 
+                 transaction.date,
+                 transaction.description, 
+                 transaction.total_debits());
+    }
+
+    // Get transactions for mid-January
+    let start_date = NaiveDate::from_ymd_opt(2024, 1, 15);
+    let end_date = NaiveDate::from_ymd_opt(2024, 1, 20);
+    let pagination2 = PaginationParams::new(1, 20)?;
+    
+    let result = ledger.get_transactions_paginated(start_date, end_date, pagination2).await?;
+    
+    println!("\n📊 Transactions from Jan 15-20, 2024:");
+    println!("   Found: {} transactions", result.total_count);
+    
+    for transaction in &result.items {
+        println!("   📅 {} - {}", transaction.date, transaction.description);
+    }
+
+    Ok(())
+}
+
+/// Example 6: Pagination navigation helpers
+async fn pagination_navigation_helpers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    let page_size = 8;
+    let mut current_page = 1;
+
+    println!("🧭 Navigation through all account pages:");
+    
+    loop {
+        let pagination = PaginationParams::new(current_page, page_size)?;
+        let result = ledger.list_accounts_paginated(pagination).await?;
+        
+        println!("\n   📄 Page {} of {} ({} items):", 
+                 result.page, 
+                 result.total_pages, 
+                 result.items.len());
+        
+        for (i, account) in result.items.iter().enumerate() {
+            println!("      {}. {} - {}", 
+                     (current_page - 1) * page_size + i as u32 + 1,
+                     account.id, 
+                     account.name);
+        }
+        
+        // Navigation info
+        let nav_info = build_navigation_info(&result);
+        println!("   🔗 Navigation: {}", nav_info);
+        
+        // Break after showing 2 pages as example
+        if current_page >= 2 {
+            println!("   (Showing first 2 pages as example...)");
+            break;
+        }
+        
+        if !result.has_next {
+            break;
+        }
+        
+        current_page += 1;
+    }
+
+    Ok(())
+}
+
+/// Example 7: Error handling and validation
+async fn error_handling_examples() -> Result<(), Box<dyn std::error::Error>> {
+    println!("⚠️  Testing validation errors:");
+
+    // Test invalid page number
+    match PaginationParams::new(0, 10) {
+        Ok(_) => println!("   ❌ Should have failed for page 0"),
+        Err(e) => println!("   ✅ Page 0 rejected: {}", e),
+    }
+
+    // Test invalid page size (too small)
+    match PaginationParams::new(1, 0) {
+        Ok(_) => println!("   ❌ Should have failed for page_size 0"),
+        Err(e) => println!("   ✅ Page size 0 rejected: {}", e),
+    }
+
+    // Test invalid page size (too large)
+    match PaginationParams::new(1, 1001) {
+        Ok(_) => println!("   ❌ Should have failed for page_size 1001"),
+        Err(e) => println!("   ✅ Page size 1001 rejected: {}", e),
+    }
+
+    // Test valid parameters
+    match PaginationParams::new(5, 25) {
+        Ok(params) => {
+            println!("   ✅ Valid params: page={}, size={}", params.page, params.page_size);
+            println!("      Offset: {}, Limit: {}", params.offset(), params.limit());
+        },
+        Err(e) => println!("   ❌ Unexpected error: {}", e),
+    }
+
+    Ok(())
+}
+
+/// Example 8: Simple pagination UI helper
+async fn pagination_ui_helper(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🖥️  Pagination UI Helper Example:");
+
+    // Simulate a UI request for page 2 of transactions
+    let page_request = 2;
+    let page_size = 6;
+    
+    let pagination = PaginationParams::new(page_request, page_size)?;
+    let result = ledger.get_transactions_paginated(None, None, pagination).await?;
+
+    // Build UI-friendly response
+    let ui_response = PaginationUIResponse {
+        items: result.items.iter().map(|t| TransactionSummary {
+            id: t.id.clone(),
+            date: t.date,
+            description: t.description.clone(),
+            amount: t.total_debits(),
+        }).collect(),
+        pagination_info: PaginationInfo {
+            current_page: result.page,
+            total_pages: result.total_pages,
+            page_size: result.page_size,
+            total_items: result.total_count,
+            has_previous: result.has_previous,
+            has_next: result.has_next,
+            start_item: ((result.page - 1) * result.page_size) + 1,
+            end_item: std::cmp::min(
+                result.page * result.page_size,
+                result.total_count,
+            ),
+        },
+    };
+
+    println!("   📊 Transaction List (UI Format):");
+    println!("   Showing items {}-{} of {}", 
+             ui_response.pagination_info.start_item,
+             ui_response.pagination_info.end_item,
+             ui_response.pagination_info.total_items);
+
+    for item in &ui_response.items {
+        println!("   • {} - {} (${:.2})", 
+                 item.date, 
+                 item.description, 
+                 item.amount);
+    }
+
+    // Generate pagination controls
+    let controls = generate_pagination_controls(&ui_response.pagination_info);
+    println!("\n   🎛️  Pagination Controls:");
+    println!("   {}", controls);
+
+    Ok(())
+}
+
+// Helper structures for UI examples
+#[derive(Debug)]
+struct TransactionSummary {
+    id: String,
+    date: NaiveDate,
+    description: String,
+    amount: BigDecimal,
+}
+
+#[derive(Debug)]
+struct PaginationInfo {
+    current_page: u32,
+    total_pages: u32,
+    page_size: u32,
+    total_items: u32,
+    has_previous: bool,
+    has_next: bool,
+    start_item: u32,
+    end_item: u32,
+}
+
+#[derive(Debug)]
+struct PaginationUIResponse {
+    items: Vec<TransactionSummary>,
+    pagination_info: PaginationInfo,
+}
+
+/// Build navigation information string
+fn build_navigation_info<T>(result: &accounting_core::PaginatedResponse<T>) -> String {
+    let mut parts = Vec::new();
+    
+    if result.has_previous {
+        parts.push(format!("← Prev"));
+    }
+    
+    parts.push(format!("Page {} of {}", result.page, result.total_pages));
+    
+    if result.has_next {
+        parts.push(format!("Next →"));
+    }
+    
+    parts.join(" | ")
+}
+
+/// Generate pagination controls for UI
+fn generate_pagination_controls(info: &PaginationInfo) -> String {
+    let mut controls = Vec::new();
+    
+    // Previous button
+    if info.has_previous {
+        controls.push(format!("[← Previous]"));
+    } else {
+        controls.push("[Previous]".to_string());
+    }
+    
+    // Page numbers (show current and adjacent)
+    let start_page = if info.current_page > 2 { info.current_page - 2 } else { 1 };
+    let end_page = std::cmp::min(start_page + 4, info.total_pages);
+    
+    if start_page > 1 {
+        controls.push("[1]".to_string());
+        if start_page > 2 {
+            controls.push("...".to_string());
+        }
+    }
+    
+    for page in start_page..=end_page {
+        if page == info.current_page {
+            controls.push(format!("[{}]", page));
+        } else {
+            controls.push(format!("{}", page));
+        }
+    }
+    
+    if end_page < info.total_pages {
+        if end_page < info.total_pages - 1 {
+            controls.push("...".to_string());
+        }
+        controls.push(format!("[{}]", info.total_pages));
+    }
+    
+    // Next button
+    if info.has_next {
+        controls.push(format!("[Next →]"));
+    } else {
+        controls.push("[Next]".to_string());
+    }
+    
+    controls.join(" ")
+}

--- a/examples/pagination_demo.rs
+++ b/examples/pagination_demo.rs
@@ -387,7 +387,7 @@ async fn pagination_navigation_helpers(ledger: &Ledger<MemoryStorage>) -> Result
             break;
         }
         
-        if !result.has_next {
+        if !paginated_result.has_next {
             break;
         }
         

--- a/examples/pagination_demo.rs
+++ b/examples/pagination_demo.rs
@@ -8,7 +8,7 @@
 //! - Error handling
 
 use accounting_core::{
-    AccountType, Entry, EntryType, Ledger, PaginationParams, Transaction,
+    AccountType, Entry, EntryType, Ledger, PaginationOption, PaginationParams, Transaction,
     utils::memory_storage::MemoryStorage,
 };
 use bigdecimal::BigDecimal;
@@ -179,7 +179,8 @@ async fn setup_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box
 async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
     // Get first page with default settings (page 1, 50 items per page)
     let pagination = PaginationParams::default();
-    let result = ledger.list_accounts_paginated(pagination).await?;
+    let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+    let result = result.to_paginated_response();
 
     println!("📊 First page (default settings):");
     println!("   Items: {}/{}", result.items.len(), result.total_count);
@@ -196,7 +197,8 @@ async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
 
     // Get first page with smaller page size
     let pagination = PaginationParams::new(1, 5)?;
-    let result = ledger.list_accounts_paginated(pagination).await?;
+    let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+    let result = result.to_paginated_response();
 
     println!("\n📊 First page (5 items per page):");
     println!("   Items: {}/{}", result.items.len(), result.total_count);
@@ -213,7 +215,8 @@ async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
 async fn paginated_accounts_by_type(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
     // Get only Asset accounts with pagination
     let pagination = PaginationParams::new(1, 10)?;
-    let result = ledger.list_accounts_by_type_paginated(AccountType::Asset, pagination).await?;
+    let result = ledger.list_accounts_by_type(AccountType::Asset, PaginationOption::Paginated(pagination)).await?;
+    let result = result.to_paginated_response();
 
     println!("📊 Asset accounts (page 1):");
     println!("   Total assets: {}", result.total_count);
@@ -225,7 +228,8 @@ async fn paginated_accounts_by_type(ledger: &Ledger<MemoryStorage>) -> Result<()
 
     // Get Revenue accounts
     let pagination2 = PaginationParams::new(1, 10)?;
-    let result = ledger.list_accounts_by_type_paginated(AccountType::Income, pagination2).await?;
+    let result = ledger.list_accounts_by_type(AccountType::Income, PaginationOption::Paginated(pagination2)).await?;
+    let result = result.to_paginated_response();
     
     println!("\n📊 Income accounts:");
     println!("   Total income accounts: {}", result.total_count);
@@ -241,7 +245,8 @@ async fn paginated_accounts_by_type(ledger: &Ledger<MemoryStorage>) -> Result<()
 async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
     // Get first page of transactions (10 per page)
     let pagination = PaginationParams::new(1, 10)?;
-    let result = ledger.get_transactions_paginated(None, None, pagination).await?;
+    let result = ledger.get_transactions(None, None, PaginationOption::Paginated(pagination)).await?;
+    let result = result.to_paginated_response();
 
     println!("📊 Recent transactions (page 1 of {}):", result.total_pages);
     println!("   Total transactions: {}", result.total_count);
@@ -258,7 +263,8 @@ async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<
     if result.has_next {
         println!("\n📊 Getting second page...");
         let pagination = PaginationParams::new(2, 10)?;
-        let result = ledger.get_transactions_paginated(None, None, pagination).await?;
+        let result = ledger.get_transactions(None, None, PaginationOption::Paginated(pagination)).await?;
+        let result = result.to_paginated_response();
         
         println!("   Page 2 - {} transactions:", result.items.len());
         for transaction in result.items.iter().take(3) {
@@ -276,12 +282,13 @@ async fn basic_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<
 async fn account_transaction_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
     // Get transactions for the cash account
     let pagination = PaginationParams::new(1, 5)?;
-    let result = ledger.get_account_transactions_paginated(
+    let result = ledger.get_account_transactions(
         "cash", 
         None, 
         None, 
-        pagination
+        PaginationOption::Paginated(pagination)
     ).await?;
+    let result = result.to_paginated_response();
 
     println!("📊 Cash account transactions:");
     println!("   Total: {} transactions", result.total_count);
@@ -315,12 +322,13 @@ async fn date_filtered_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
     let end_date = NaiveDate::from_ymd_opt(2024, 1, 7);
     let pagination = PaginationParams::new(1, 20)?;
     
-    let result = ledger.get_transactions_paginated(start_date, end_date, pagination).await?;
+    let result = ledger.get_transactions(start_date, end_date, PaginationOption::Paginated(pagination)).await?;
+    let paginated_result = result.to_paginated_response();
 
     println!("📊 Transactions from Jan 1-7, 2024:");
-    println!("   Found: {} transactions", result.total_count);
+    println!("   Found: {} transactions", paginated_result.total_count);
     
-    for transaction in &result.items {
+    for transaction in &paginated_result.items {
         println!("   📅 {} - {} (${:.2})", 
                  transaction.date,
                  transaction.description, 
@@ -332,12 +340,13 @@ async fn date_filtered_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
     let end_date = NaiveDate::from_ymd_opt(2024, 1, 20);
     let pagination2 = PaginationParams::new(1, 20)?;
     
-    let result = ledger.get_transactions_paginated(start_date, end_date, pagination2).await?;
+    let result = ledger.get_transactions(start_date, end_date, PaginationOption::Paginated(pagination2)).await?;
+    let paginated_result = result.to_paginated_response();
     
     println!("\n📊 Transactions from Jan 15-20, 2024:");
-    println!("   Found: {} transactions", result.total_count);
+    println!("   Found: {} transactions", paginated_result.total_count);
     
-    for transaction in &result.items {
+    for transaction in &paginated_result.items {
         println!("   📅 {} - {}", transaction.date, transaction.description);
     }
 
@@ -353,14 +362,15 @@ async fn pagination_navigation_helpers(ledger: &Ledger<MemoryStorage>) -> Result
     
     loop {
         let pagination = PaginationParams::new(current_page, page_size)?;
-        let result = ledger.list_accounts_paginated(pagination).await?;
+        let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+        let paginated_result = result.to_paginated_response();
         
         println!("\n   📄 Page {} of {} ({} items):", 
-                 result.page, 
-                 result.total_pages, 
-                 result.items.len());
+                 paginated_result.page, 
+                 paginated_result.total_pages, 
+                 paginated_result.items.len());
         
-        for (i, account) in result.items.iter().enumerate() {
+        for (i, account) in paginated_result.items.iter().enumerate() {
             println!("      {}. {} - {}", 
                      (current_page - 1) * page_size + i as u32 + 1,
                      account.id, 
@@ -368,7 +378,7 @@ async fn pagination_navigation_helpers(ledger: &Ledger<MemoryStorage>) -> Result
         }
         
         // Navigation info
-        let nav_info = build_navigation_info(&result);
+        let nav_info = build_navigation_info(&paginated_result);
         println!("   🔗 Navigation: {}", nav_info);
         
         // Break after showing 2 pages as example
@@ -430,7 +440,8 @@ async fn pagination_ui_helper(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<
     let page_size = 6;
     
     let pagination = PaginationParams::new(page_request, page_size)?;
-    let result = ledger.get_transactions_paginated(None, None, pagination).await?;
+    let result = ledger.get_transactions(None, None, PaginationOption::Paginated(pagination)).await?;
+    let result = result.to_paginated_response();
 
     // Build UI-friendly response
     let ui_response = PaginationUIResponse {

--- a/examples/pagination_demo.rs
+++ b/examples/pagination_demo.rs
@@ -205,7 +205,7 @@ async fn basic_account_pagination(ledger: &Ledger<MemoryStorage>) -> Result<(), 
     println!("   Page: {} of {}", result.page, result.total_pages);
     
     for account in &result.items {
-        println!("   • {} - {} ({})", account.id, account.name, format!("{:?}", account.account_type));
+        println!("   • {} - {} ({:?})", account.id, account.name, account.account_type);
     }
 
     Ok(())
@@ -489,6 +489,7 @@ async fn pagination_ui_helper(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<
 
 // Helper structures for UI examples
 #[derive(Debug)]
+#[allow(dead_code)]
 struct TransactionSummary {
     id: String,
     date: NaiveDate,
@@ -497,6 +498,7 @@ struct TransactionSummary {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct PaginationInfo {
     current_page: u32,
     total_pages: u32,
@@ -519,13 +521,13 @@ fn build_navigation_info<T>(result: &accounting_core::PaginatedResponse<T>) -> S
     let mut parts = Vec::new();
     
     if result.has_previous {
-        parts.push(format!("← Prev"));
+        parts.push("← Prev".to_string());
     }
     
     parts.push(format!("Page {} of {}", result.page, result.total_pages));
     
     if result.has_next {
-        parts.push(format!("Next →"));
+        parts.push("Next →".to_string());
     }
     
     parts.join(" | ")
@@ -537,7 +539,7 @@ fn generate_pagination_controls(info: &PaginationInfo) -> String {
     
     // Previous button
     if info.has_previous {
-        controls.push(format!("[← Previous]"));
+        controls.push("[← Previous]".to_string());
     } else {
         controls.push("[Previous]".to_string());
     }
@@ -570,7 +572,7 @@ fn generate_pagination_controls(info: &PaginationInfo) -> String {
     
     // Next button
     if info.has_next {
-        controls.push(format!("[Next →]"));
+        controls.push("[Next →]".to_string());
     } else {
         controls.push("[Next]".to_string());
     }

--- a/examples/web_integration.rs
+++ b/examples/web_integration.rs
@@ -4,8 +4,7 @@
 //! including error handling, query parameter parsing, and response formatting.
 
 use accounting_core::{
-    AccountType, Ledger, PaginationOption, PaginationParams,
-    utils::memory_storage::MemoryStorage,
+    utils::memory_storage::MemoryStorage, AccountType, Ledger, PaginationOption, PaginationParams,
 };
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let storage = MemoryStorage::new();
     let mut ledger = Ledger::new(storage);
-    
+
     // Create sample data
     create_sample_data(&mut ledger).await?;
 
@@ -23,11 +22,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     axum_style_handlers(&ledger).await?;
     actix_style_handlers(&ledger).await?;
     warp_style_handlers(&ledger).await?;
-    
+
     Ok(())
 }
 
-async fn create_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_sample_data(
+    ledger: &mut Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Create 15 sample accounts for demonstration
     let accounts = [
         ("cash", "Cash Account", AccountType::Asset),
@@ -35,7 +36,11 @@ async fn create_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Bo
         ("inventory", "Inventory", AccountType::Asset),
         ("equipment", "Office Equipment", AccountType::Asset),
         ("building", "Office Building", AccountType::Asset),
-        ("accounts_payable", "Accounts Payable", AccountType::Liability),
+        (
+            "accounts_payable",
+            "Accounts Payable",
+            AccountType::Liability,
+        ),
         ("loan", "Business Loan", AccountType::Liability),
         ("mortgage", "Building Mortgage", AccountType::Liability),
         ("equity", "Owner's Equity", AccountType::Equity),
@@ -48,25 +53,24 @@ async fn create_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Bo
     ];
 
     for (id, name, account_type) in accounts {
-        ledger.create_account(
-            id.to_string(),
-            name.to_string(),
-            account_type,
-            None,
-        ).await?;
+        ledger
+            .create_account(id.to_string(), name.to_string(), account_type, None)
+            .await?;
     }
 
     Ok(())
 }
 
 /// Axum-style request handlers
-async fn axum_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn axum_style_handlers(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("🦀 Axum-Style Handler Examples");
     println!("{}", "=".repeat(40));
 
     // Simulate Axum query parameters
     println!("\n📞 GET /accounts?page=2&per_page=5&type=asset");
-    
+
     let query_params = AxumAccountsQuery {
         page: Some(2),
         per_page: Some(5),
@@ -88,7 +92,7 @@ async fn axum_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<d
 
     // Test error handling
     println!("\n📞 GET /accounts?page=0&per_page=5 (invalid)");
-    
+
     let bad_query = AxumAccountsQuery {
         page: Some(0), // Invalid page
         per_page: Some(5),
@@ -109,13 +113,15 @@ async fn axum_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<d
 }
 
 /// Actix Web-style request handlers  
-async fn actix_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn actix_style_handlers(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("\n\n🕸️  Actix Web-Style Handler Examples");
     println!("{}", "=".repeat(40));
 
     // Simulate Actix web::Query
     println!("\n📞 GET /api/accounts?page=1&limit=10");
-    
+
     let query = ActixQuery {
         page: 1,
         limit: 10,
@@ -126,7 +132,7 @@ async fn actix_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<
     println!("✅ Status: 200 OK");
     println!("📦 Headers: X-Total-Count: {}", response.total);
     println!("📦 Body: {} accounts returned", response.accounts.len());
-    
+
     // Show first few accounts
     for account in response.accounts.iter().take(3) {
         println!("   • {} - {}", account.code, account.name);
@@ -134,7 +140,7 @@ async fn actix_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<
 
     // Test with filtering
     println!("\n📞 GET /api/accounts?page=1&limit=5&filter=liability");
-    
+
     let query = ActixQuery {
         page: 1,
         limit: 5,
@@ -142,39 +148,44 @@ async fn actix_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<
     };
 
     let response = actix_get_accounts(ledger, query).await?;
-    println!("✅ Status: 200 OK");  
-    println!("📦 Filtered results: {} liability accounts", response.accounts.len());
+    println!("✅ Status: 200 OK");
+    println!(
+        "📦 Filtered results: {} liability accounts",
+        response.accounts.len()
+    );
 
     Ok(())
 }
 
 /// Warp-style request handlers
-async fn warp_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+async fn warp_style_handlers(
+    ledger: &Ledger<MemoryStorage>,
+) -> Result<(), Box<dyn std::error::Error>> {
     println!("\n\n🌊 Warp-Style Handler Examples");
     println!("{}", "=".repeat(40));
 
     // Simulate Warp query parameters
     println!("\n📞 GET /accounts?offset=5&limit=3&type=income");
-    
+
     let params = WarpQueryParams {
         offset: Some(5),
-        limit: Some(3), 
+        limit: Some(3),
         account_type: Some("income".to_string()),
     };
 
     let response = warp_accounts_handler(ledger, params).await?;
-    
+
     println!("✅ Status: 200 OK");
     println!("📦 Response Headers:");
     println!("   X-Total-Count: {}", response.meta.total);
     println!("   X-Page-Count: {}", response.meta.page_count);
-    
+
     println!("📦 Response Body:");
     for account in &response.data {
-        println!("   💰 {} - {} (Balance: ${})", 
-                 account.id, 
-                 account.name, 
-                 account.current_balance);
+        println!(
+            "   💰 {} - {} (Balance: ${})",
+            account.id, account.name, account.current_balance
+        );
     }
 
     Ok(())
@@ -223,26 +234,35 @@ async fn axum_list_accounts(
 ) -> Result<AxumAccountsResponse, String> {
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(20);
-    
+
     let pagination = PaginationParams::new(page, per_page)
         .map_err(|e| format!("Invalid pagination parameters: {}", e))?;
 
     let result = if let Some(type_str) = query.account_type {
-        let account_type = parse_account_type(&type_str)
-            .map_err(|e| format!("Invalid account type: {}", e))?;
-        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await
+        let account_type =
+            parse_account_type(&type_str).map_err(|e| format!("Invalid account type: {}", e))?;
+        ledger
+            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+            .await
     } else {
-        ledger.list_accounts(PaginationOption::Paginated(pagination)).await
-    }.map_err(|e| format!("Database error: {}", e))?;
+        ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await
+    }
+    .map_err(|e| format!("Database error: {}", e))?;
 
     let result = result.to_paginated_response();
-    let data = result.items.into_iter().map(|account| AxumAccountDto {
-        id: account.id,
-        name: account.name,
-        account_type: format!("{:?}", account.account_type),
-        balance: account.balance.to_string(),
-        created_at: account.created_at.format("%Y-%m-%d %H:%M:%S").to_string(),
-    }).collect();
+    let data = result
+        .items
+        .into_iter()
+        .map(|account| AxumAccountDto {
+            id: account.id,
+            name: account.name,
+            account_type: format!("{:?}", account.account_type),
+            balance: account.balance.to_string(),
+            created_at: account.created_at.format("%Y-%m-%d %H:%M:%S").to_string(),
+        })
+        .collect();
 
     Ok(AxumAccountsResponse {
         data,
@@ -287,21 +307,29 @@ async fn actix_get_accounts(
     query: ActixQuery,
 ) -> Result<ActixAccountsResponse, Box<dyn std::error::Error>> {
     let pagination = PaginationParams::new(query.page, query.limit)?;
-    
+
     let result = if let Some(filter) = query.filter {
         let account_type = parse_account_type(&filter)?;
-        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+            .await?
     } else {
-        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?
     };
     let result = result.to_paginated_response();
 
-    let accounts = result.items.into_iter().map(|account| ActixAccountDto {
-        code: account.id,
-        name: account.name,
-        type_name: format!("{:?}", account.account_type),
-        balance: account.balance.to_string().parse().unwrap_or(0.0),
-    }).collect();
+    let accounts = result
+        .items
+        .into_iter()
+        .map(|account| ActixAccountDto {
+            code: account.id,
+            name: account.name,
+            type_name: format!("{:?}", account.account_type),
+            balance: account.balance.to_string().parse().unwrap_or(0.0),
+        })
+        .collect();
 
     Ok(ActixAccountsResponse {
         accounts,
@@ -312,7 +340,7 @@ async fn actix_get_accounts(
     })
 }
 
-// Warp-style types and handlers  
+// Warp-style types and handlers
 #[derive(Debug, Deserialize)]
 struct WarpQueryParams {
     offset: Option<u32>,
@@ -335,7 +363,7 @@ struct WarpAccountDto {
     current_balance: String,
 }
 
-#[derive(Debug, Serialize)] 
+#[derive(Debug, Serialize)]
 struct WarpMeta {
     total: u32,
     offset: u32,
@@ -349,25 +377,33 @@ async fn warp_accounts_handler(
 ) -> Result<WarpAccountsResponse, Box<dyn std::error::Error>> {
     let limit = params.limit.unwrap_or(50);
     let offset = params.offset.unwrap_or(0);
-    
+
     // Convert offset to page number
     let page = (offset / limit) + 1;
     let pagination = PaginationParams::new(page, limit)?;
 
     let result = if let Some(type_str) = params.account_type {
         let account_type = parse_account_type(&type_str)?;
-        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+            .await?
     } else {
-        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
+        ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?
     };
     let result = result.to_paginated_response();
 
-    let data = result.items.into_iter().map(|account| WarpAccountDto {
-        id: account.id,
-        name: account.name,
-        type_code: account_type_to_code(&account.account_type),
-        current_balance: account.balance.to_string(),
-    }).collect();
+    let data = result
+        .items
+        .into_iter()
+        .map(|account| WarpAccountDto {
+            id: account.id,
+            name: account.name,
+            type_code: account_type_to_code(&account.account_type),
+            current_balance: account.balance.to_string(),
+        })
+        .collect();
 
     Ok(WarpAccountsResponse {
         data,

--- a/examples/web_integration.rs
+++ b/examples/web_integration.rs
@@ -293,6 +293,7 @@ async fn actix_get_accounts(
     } else {
         ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
+    let result = result.to_paginated_response();
 
     let accounts = result.items.into_iter().map(|account| ActixAccountDto {
         code: account.id,
@@ -358,6 +359,7 @@ async fn warp_accounts_handler(
     } else {
         ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
+    let result = result.to_paginated_response();
 
     let data = result.items.into_iter().map(|account| WarpAccountDto {
         id: account.id,

--- a/examples/web_integration.rs
+++ b/examples/web_integration.rs
@@ -182,6 +182,7 @@ async fn warp_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<d
 
 // Axum-style types and handlers
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct AxumAccountsQuery {
     page: Option<u32>,
     per_page: Option<u32>,

--- a/examples/web_integration.rs
+++ b/examples/web_integration.rs
@@ -4,11 +4,10 @@
 //! including error handling, query parameter parsing, and response formatting.
 
 use accounting_core::{
-    AccountType, Ledger, PaginationParams, PaginatedResponse,
-    utils::memory_storage::MemoryStorage, Account,
+    AccountType, Ledger, PaginationOption, PaginationParams,
+    utils::memory_storage::MemoryStorage,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -230,11 +229,12 @@ async fn axum_list_accounts(
     let result = if let Some(type_str) = query.account_type {
         let account_type = parse_account_type(&type_str)
             .map_err(|e| format!("Invalid account type: {}", e))?;
-        ledger.list_accounts_by_type_paginated(account_type, pagination).await
+        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await
     } else {
-        ledger.list_accounts_paginated(pagination).await
+        ledger.list_accounts(PaginationOption::Paginated(pagination)).await
     }.map_err(|e| format!("Database error: {}", e))?;
 
+    let result = result.to_paginated_response();
     let data = result.items.into_iter().map(|account| AxumAccountDto {
         id: account.id,
         name: account.name,
@@ -289,9 +289,9 @@ async fn actix_get_accounts(
     
     let result = if let Some(filter) = query.filter {
         let account_type = parse_account_type(&filter)?;
-        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
     } else {
-        ledger.list_accounts_paginated(pagination).await?
+        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
 
     let accounts = result.items.into_iter().map(|account| ActixAccountDto {
@@ -354,9 +354,9 @@ async fn warp_accounts_handler(
 
     let result = if let Some(type_str) = params.account_type {
         let account_type = parse_account_type(&type_str)?;
-        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+        ledger.list_accounts_by_type(account_type, PaginationOption::Paginated(pagination)).await?
     } else {
-        ledger.list_accounts_paginated(pagination).await?
+        ledger.list_accounts(PaginationOption::Paginated(pagination)).await?
     };
 
     let data = result.items.into_iter().map(|account| WarpAccountDto {

--- a/examples/web_integration.rs
+++ b/examples/web_integration.rs
@@ -1,0 +1,400 @@
+//! Web Framework Integration Examples
+//!
+//! This example demonstrates how to integrate pagination with popular web frameworks
+//! including error handling, query parameter parsing, and response formatting.
+
+use accounting_core::{
+    AccountType, Ledger, PaginationParams, PaginatedResponse,
+    utils::memory_storage::MemoryStorage, Account,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🌐 Web Framework Integration Examples\n");
+
+    let storage = MemoryStorage::new();
+    let mut ledger = Ledger::new(storage);
+    
+    // Create sample data
+    create_sample_data(&mut ledger).await?;
+
+    // Demonstrate different web framework patterns
+    axum_style_handlers(&ledger).await?;
+    actix_style_handlers(&ledger).await?;
+    warp_style_handlers(&ledger).await?;
+    
+    Ok(())
+}
+
+async fn create_sample_data(ledger: &mut Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    // Create 15 sample accounts for demonstration
+    let accounts = [
+        ("cash", "Cash Account", AccountType::Asset),
+        ("bank", "Bank Account", AccountType::Asset),
+        ("inventory", "Inventory", AccountType::Asset),
+        ("equipment", "Office Equipment", AccountType::Asset),
+        ("building", "Office Building", AccountType::Asset),
+        ("accounts_payable", "Accounts Payable", AccountType::Liability),
+        ("loan", "Business Loan", AccountType::Liability),
+        ("mortgage", "Building Mortgage", AccountType::Liability),
+        ("equity", "Owner's Equity", AccountType::Equity),
+        ("retained", "Retained Earnings", AccountType::Equity),
+        ("sales", "Sales Revenue", AccountType::Income),
+        ("services", "Service Revenue", AccountType::Income),
+        ("rent", "Rent Expense", AccountType::Expense),
+        ("utilities", "Utilities Expense", AccountType::Expense),
+        ("marketing", "Marketing Expense", AccountType::Expense),
+    ];
+
+    for (id, name, account_type) in accounts {
+        ledger.create_account(
+            id.to_string(),
+            name.to_string(),
+            account_type,
+            None,
+        ).await?;
+    }
+
+    Ok(())
+}
+
+/// Axum-style request handlers
+async fn axum_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🦀 Axum-Style Handler Examples");
+    println!("{}", "=".repeat(40));
+
+    // Simulate Axum query parameters
+    println!("\n📞 GET /accounts?page=2&per_page=5&type=asset");
+    
+    let query_params = AxumAccountsQuery {
+        page: Some(2),
+        per_page: Some(5),
+        account_type: Some("asset".to_string()),
+        sort: None,
+        order: None,
+    };
+
+    match axum_list_accounts(ledger, query_params).await {
+        Ok(response) => {
+            println!("✅ Status: 200 OK");
+            println!("📦 Response: {}", serde_json::to_string_pretty(&response)?);
+        }
+        Err(e) => {
+            println!("❌ Status: 400 Bad Request");
+            println!("📦 Error: {}", e);
+        }
+    }
+
+    // Test error handling
+    println!("\n📞 GET /accounts?page=0&per_page=5 (invalid)");
+    
+    let bad_query = AxumAccountsQuery {
+        page: Some(0), // Invalid page
+        per_page: Some(5),
+        account_type: None,
+        sort: None,
+        order: None,
+    };
+
+    match axum_list_accounts(ledger, bad_query).await {
+        Ok(_) => println!("❌ Should have failed!"),
+        Err(e) => {
+            println!("✅ Status: 400 Bad Request");
+            println!("📦 Error: {}", e);
+        }
+    }
+
+    Ok(())
+}
+
+/// Actix Web-style request handlers  
+async fn actix_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n\n🕸️  Actix Web-Style Handler Examples");
+    println!("{}", "=".repeat(40));
+
+    // Simulate Actix web::Query
+    println!("\n📞 GET /api/accounts?page=1&limit=10");
+    
+    let query = ActixQuery {
+        page: 1,
+        limit: 10,
+        filter: None,
+    };
+
+    let response = actix_get_accounts(ledger, query).await?;
+    println!("✅ Status: 200 OK");
+    println!("📦 Headers: X-Total-Count: {}", response.total);
+    println!("📦 Body: {} accounts returned", response.accounts.len());
+    
+    // Show first few accounts
+    for account in response.accounts.iter().take(3) {
+        println!("   • {} - {}", account.code, account.name);
+    }
+
+    // Test with filtering
+    println!("\n📞 GET /api/accounts?page=1&limit=5&filter=liability");
+    
+    let query = ActixQuery {
+        page: 1,
+        limit: 5,
+        filter: Some("liability".to_string()),
+    };
+
+    let response = actix_get_accounts(ledger, query).await?;
+    println!("✅ Status: 200 OK");  
+    println!("📦 Filtered results: {} liability accounts", response.accounts.len());
+
+    Ok(())
+}
+
+/// Warp-style request handlers
+async fn warp_style_handlers(ledger: &Ledger<MemoryStorage>) -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n\n🌊 Warp-Style Handler Examples");
+    println!("{}", "=".repeat(40));
+
+    // Simulate Warp query parameters
+    println!("\n📞 GET /accounts?offset=5&limit=3&type=income");
+    
+    let params = WarpQueryParams {
+        offset: Some(5),
+        limit: Some(3), 
+        account_type: Some("income".to_string()),
+    };
+
+    let response = warp_accounts_handler(ledger, params).await?;
+    
+    println!("✅ Status: 200 OK");
+    println!("📦 Response Headers:");
+    println!("   X-Total-Count: {}", response.meta.total);
+    println!("   X-Page-Count: {}", response.meta.page_count);
+    
+    println!("📦 Response Body:");
+    for account in &response.data {
+        println!("   💰 {} - {} (Balance: ${})", 
+                 account.id, 
+                 account.name, 
+                 account.current_balance);
+    }
+
+    Ok(())
+}
+
+// Axum-style types and handlers
+#[derive(Debug, Deserialize)]
+struct AxumAccountsQuery {
+    page: Option<u32>,
+    per_page: Option<u32>,
+    #[serde(rename = "type")]
+    account_type: Option<String>,
+    sort: Option<String>,
+    order: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct AxumAccountsResponse {
+    data: Vec<AxumAccountDto>,
+    pagination: AxumPaginationInfo,
+}
+
+#[derive(Debug, Serialize)]
+struct AxumAccountDto {
+    id: String,
+    name: String,
+    account_type: String,
+    balance: String,
+    created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AxumPaginationInfo {
+    page: u32,
+    per_page: u32,
+    total: u32,
+    pages: u32,
+    has_next: bool,
+    has_prev: bool,
+}
+
+async fn axum_list_accounts(
+    ledger: &Ledger<MemoryStorage>,
+    query: AxumAccountsQuery,
+) -> Result<AxumAccountsResponse, String> {
+    let page = query.page.unwrap_or(1);
+    let per_page = query.per_page.unwrap_or(20);
+    
+    let pagination = PaginationParams::new(page, per_page)
+        .map_err(|e| format!("Invalid pagination parameters: {}", e))?;
+
+    let result = if let Some(type_str) = query.account_type {
+        let account_type = parse_account_type(&type_str)
+            .map_err(|e| format!("Invalid account type: {}", e))?;
+        ledger.list_accounts_by_type_paginated(account_type, pagination).await
+    } else {
+        ledger.list_accounts_paginated(pagination).await
+    }.map_err(|e| format!("Database error: {}", e))?;
+
+    let data = result.items.into_iter().map(|account| AxumAccountDto {
+        id: account.id,
+        name: account.name,
+        account_type: format!("{:?}", account.account_type),
+        balance: account.balance.to_string(),
+        created_at: account.created_at.format("%Y-%m-%d %H:%M:%S").to_string(),
+    }).collect();
+
+    Ok(AxumAccountsResponse {
+        data,
+        pagination: AxumPaginationInfo {
+            page: result.page,
+            per_page: result.page_size,
+            total: result.total_count,
+            pages: result.total_pages,
+            has_next: result.has_next,
+            has_prev: result.has_previous,
+        },
+    })
+}
+
+// Actix Web-style types and handlers
+#[derive(Debug, Deserialize)]
+struct ActixQuery {
+    page: u32,
+    limit: u32,
+    filter: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ActixAccountsResponse {
+    accounts: Vec<ActixAccountDto>,
+    page: u32,
+    limit: u32,
+    total: u32,
+    pages: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct ActixAccountDto {
+    code: String,
+    name: String,
+    type_name: String,
+    balance: f64,
+}
+
+async fn actix_get_accounts(
+    ledger: &Ledger<MemoryStorage>,
+    query: ActixQuery,
+) -> Result<ActixAccountsResponse, Box<dyn std::error::Error>> {
+    let pagination = PaginationParams::new(query.page, query.limit)?;
+    
+    let result = if let Some(filter) = query.filter {
+        let account_type = parse_account_type(&filter)?;
+        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+    } else {
+        ledger.list_accounts_paginated(pagination).await?
+    };
+
+    let accounts = result.items.into_iter().map(|account| ActixAccountDto {
+        code: account.id,
+        name: account.name,
+        type_name: format!("{:?}", account.account_type),
+        balance: account.balance.to_string().parse().unwrap_or(0.0),
+    }).collect();
+
+    Ok(ActixAccountsResponse {
+        accounts,
+        page: result.page,
+        limit: result.page_size,
+        total: result.total_count,
+        pages: result.total_pages,
+    })
+}
+
+// Warp-style types and handlers  
+#[derive(Debug, Deserialize)]
+struct WarpQueryParams {
+    offset: Option<u32>,
+    limit: Option<u32>,
+    #[serde(rename = "type")]
+    account_type: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct WarpAccountsResponse {
+    data: Vec<WarpAccountDto>,
+    meta: WarpMeta,
+}
+
+#[derive(Debug, Serialize)]
+struct WarpAccountDto {
+    id: String,
+    name: String,
+    type_code: String,
+    current_balance: String,
+}
+
+#[derive(Debug, Serialize)] 
+struct WarpMeta {
+    total: u32,
+    offset: u32,
+    limit: u32,
+    page_count: u32,
+}
+
+async fn warp_accounts_handler(
+    ledger: &Ledger<MemoryStorage>,
+    params: WarpQueryParams,
+) -> Result<WarpAccountsResponse, Box<dyn std::error::Error>> {
+    let limit = params.limit.unwrap_or(50);
+    let offset = params.offset.unwrap_or(0);
+    
+    // Convert offset to page number
+    let page = (offset / limit) + 1;
+    let pagination = PaginationParams::new(page, limit)?;
+
+    let result = if let Some(type_str) = params.account_type {
+        let account_type = parse_account_type(&type_str)?;
+        ledger.list_accounts_by_type_paginated(account_type, pagination).await?
+    } else {
+        ledger.list_accounts_paginated(pagination).await?
+    };
+
+    let data = result.items.into_iter().map(|account| WarpAccountDto {
+        id: account.id,
+        name: account.name,
+        type_code: account_type_to_code(&account.account_type),
+        current_balance: account.balance.to_string(),
+    }).collect();
+
+    Ok(WarpAccountsResponse {
+        data,
+        meta: WarpMeta {
+            total: result.total_count,
+            offset,
+            limit,
+            page_count: result.total_pages,
+        },
+    })
+}
+
+// Helper functions
+fn parse_account_type(type_str: &str) -> Result<AccountType, Box<dyn std::error::Error>> {
+    match type_str.to_lowercase().as_str() {
+        "asset" => Ok(AccountType::Asset),
+        "liability" => Ok(AccountType::Liability),
+        "equity" => Ok(AccountType::Equity),
+        "income" => Ok(AccountType::Income),
+        "expense" => Ok(AccountType::Expense),
+        _ => Err(format!("Unknown account type: {}", type_str).into()),
+    }
+}
+
+fn account_type_to_code(account_type: &AccountType) -> String {
+    match account_type {
+        AccountType::Asset => "AST".to_string(),
+        AccountType::Liability => "LBL".to_string(),
+        AccountType::Equity => "EQY".to_string(),
+        AccountType::Income => "INC".to_string(),
+        AccountType::Expense => "EXP".to_string(),
+    }
+}

--- a/src/ledger/account.rs
+++ b/src/ledger/account.rs
@@ -76,17 +76,21 @@ impl<S: LedgerStorage> AccountManager<S> {
             .ok_or_else(|| LedgerError::AccountNotFound(account_id.to_string()))
     }
 
-    /// List all accounts
-    pub async fn list_accounts(&self) -> LedgerResult<Vec<Account>> {
-        self.storage.list_accounts(None).await
+    /// List all accounts with optional pagination
+    pub async fn list_accounts(
+        &self,
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Account>> {
+        self.storage.list_accounts(None, pagination).await
     }
 
-    /// List accounts by type
+    /// List accounts by type with optional pagination
     pub async fn list_accounts_by_type(
         &self,
         account_type: AccountType,
-    ) -> LedgerResult<Vec<Account>> {
-        self.storage.list_accounts(Some(account_type)).await
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Account>> {
+        self.storage.list_accounts(Some(account_type), pagination).await
     }
 
     /// Update an account
@@ -144,7 +148,8 @@ impl<S: LedgerStorage> StandardChartOfAccounts<S> {
 #[async_trait::async_trait]
 impl<S: LedgerStorage> ChartOfAccounts for StandardChartOfAccounts<S> {
     async fn get_chart(&self) -> LedgerResult<Vec<Account>> {
-        self.account_manager.list_accounts().await
+        let response = self.account_manager.list_accounts(PaginationOption::All).await?;
+        Ok(response.into_items())
     }
 
     async fn add_account(&mut self, account: Account) -> LedgerResult<()> {
@@ -152,8 +157,9 @@ impl<S: LedgerStorage> ChartOfAccounts for StandardChartOfAccounts<S> {
     }
 
     async fn get_child_accounts(&self, parent_id: &str) -> LedgerResult<Vec<Account>> {
-        let all_accounts = self.account_manager.list_accounts().await?;
+        let all_accounts = self.account_manager.list_accounts(PaginationOption::All).await?;
         Ok(all_accounts
+            .into_items()
             .into_iter()
             .filter(|account| account.parent_id.as_deref() == Some(parent_id))
             .collect())

--- a/src/ledger/account.rs
+++ b/src/ledger/account.rs
@@ -90,7 +90,9 @@ impl<S: LedgerStorage> AccountManager<S> {
         account_type: AccountType,
         pagination: PaginationOption,
     ) -> LedgerResult<ListResponse<Account>> {
-        self.storage.list_accounts(Some(account_type), pagination).await
+        self.storage
+            .list_accounts(Some(account_type), pagination)
+            .await
     }
 
     /// Update an account
@@ -148,7 +150,10 @@ impl<S: LedgerStorage> StandardChartOfAccounts<S> {
 #[async_trait::async_trait]
 impl<S: LedgerStorage> ChartOfAccounts for StandardChartOfAccounts<S> {
     async fn get_chart(&self) -> LedgerResult<Vec<Account>> {
-        let response = self.account_manager.list_accounts(PaginationOption::All).await?;
+        let response = self
+            .account_manager
+            .list_accounts(PaginationOption::All)
+            .await?;
         Ok(response.into_items())
     }
 
@@ -157,7 +162,10 @@ impl<S: LedgerStorage> ChartOfAccounts for StandardChartOfAccounts<S> {
     }
 
     async fn get_child_accounts(&self, parent_id: &str) -> LedgerResult<Vec<Account>> {
-        let all_accounts = self.account_manager.list_accounts(PaginationOption::All).await?;
+        let all_accounts = self
+            .account_manager
+            .list_accounts(PaginationOption::All)
+            .await?;
         Ok(all_accounts
             .into_items()
             .into_iter()

--- a/src/ledger/core.rs
+++ b/src/ledger/core.rs
@@ -76,7 +76,10 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
 
     /// Convenience method: List all accounts without pagination
     pub async fn list_all_accounts(&self) -> LedgerResult<Vec<Account>> {
-        let response = self.account_manager.list_accounts(PaginationOption::All).await?;
+        let response = self
+            .account_manager
+            .list_accounts(PaginationOption::All)
+            .await?;
         Ok(response.into_items())
     }
 
@@ -85,12 +88,12 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         &self,
         account_type: AccountType,
     ) -> LedgerResult<Vec<Account>> {
-        let response = self.account_manager
+        let response = self
+            .account_manager
             .list_accounts_by_type(account_type, PaginationOption::All)
             .await?;
         Ok(response.into_items())
     }
-
 
     /// Update an account
     pub async fn update_account(&mut self, account: &Account) -> LedgerResult<()> {
@@ -149,7 +152,8 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> LedgerResult<Vec<Transaction>> {
-        let response = self.transaction_manager
+        let response = self
+            .transaction_manager
             .get_account_transactions(account_id, start_date, end_date, PaginationOption::All)
             .await?;
         Ok(response.into_items())
@@ -161,12 +165,12 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> LedgerResult<Vec<Transaction>> {
-        let response = self.transaction_manager
+        let response = self
+            .transaction_manager
             .get_transactions(start_date, end_date, PaginationOption::All)
             .await?;
         Ok(response.into_items())
     }
-
 
     /// Update a transaction
     pub async fn update_transaction(&mut self, transaction: &Transaction) -> LedgerResult<()> {
@@ -545,7 +549,10 @@ mod tests {
 
         // Test pagination with default page size using unified API
         let pagination = PaginationParams::default(); // page: 1, page_size: 50
-        let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let result = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await
+            .unwrap();
         let result = result.to_paginated_response();
 
         assert_eq!(result.items.len(), 25); // All accounts fit in one page
@@ -564,7 +571,10 @@ mod tests {
 
         // Test pagination with smaller page size using unified API
         let pagination = PaginationParams::new(1, 10).unwrap();
-        let page1_response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let page1_response = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await
+            .unwrap();
         let page1 = page1_response.to_paginated_response();
 
         assert_eq!(page1.items.len(), 10);
@@ -577,7 +587,10 @@ mod tests {
 
         // Test second page
         let pagination = PaginationParams::new(2, 10).unwrap();
-        let page2_response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let page2_response = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await
+            .unwrap();
         let page2 = page2_response.to_paginated_response();
 
         assert_eq!(page2.items.len(), 10);
@@ -588,7 +601,10 @@ mod tests {
 
         // Test last page
         let pagination = PaginationParams::new(3, 10).unwrap();
-        let page3_response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let page3_response = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await
+            .unwrap();
         let page3 = page3_response.to_paginated_response();
 
         assert_eq!(page3.items.len(), 5); // Remaining accounts
@@ -654,13 +670,19 @@ mod tests {
         }
 
         // Test getting all transactions without pagination
-        let all_result = ledger.get_transactions(None, None, PaginationOption::All).await.unwrap();
+        let all_result = ledger
+            .get_transactions(None, None, PaginationOption::All)
+            .await
+            .unwrap();
         assert_eq!(all_result.items().len(), 15);
         assert!(!all_result.is_paginated());
 
         // Test unified API with pagination
         let pagination_option = PaginationOption::Paginated(PaginationParams::new(1, 5).unwrap());
-        let unified_result = ledger.get_transactions(None, None, pagination_option).await.unwrap();
+        let unified_result = ledger
+            .get_transactions(None, None, pagination_option)
+            .await
+            .unwrap();
         assert!(unified_result.is_paginated());
         assert_eq!(unified_result.items().len(), 5);
 
@@ -689,7 +711,12 @@ mod tests {
         // Test account-specific transactions pagination
         let pagination = PaginationParams::new(1, 10).unwrap();
         let account_result_response = ledger
-            .get_account_transactions(&cash_account.id, None, None, PaginationOption::Paginated(pagination))
+            .get_account_transactions(
+                &cash_account.id,
+                None,
+                None,
+                PaginationOption::Paginated(pagination),
+            )
             .await
             .unwrap();
         let account_result = account_result_response.to_paginated_response();
@@ -699,10 +726,7 @@ mod tests {
 
         // All transactions should affect the cash account
         for txn in &account_result.items {
-            assert!(txn
-                .entries
-                .iter()
-                .any(|e| e.account_id == cash_account.id));
+            assert!(txn.entries.iter().any(|e| e.account_id == cash_account.id));
         }
     }
 
@@ -753,12 +777,12 @@ mod tests {
         }
 
         // Test that single unified method can handle both cases
-        
+
         // Case 1: Get all items (no pagination)
         let all_accounts = ledger.list_accounts(PaginationOption::All).await.unwrap();
         assert!(!all_accounts.is_paginated());
         assert_eq!(all_accounts.items().len(), 10);
-        
+
         // Case 2: Get paginated results
         let pagination = PaginationParams::new(1, 5).unwrap();
         let paginated_accounts = ledger
@@ -767,14 +791,14 @@ mod tests {
             .unwrap();
         assert!(paginated_accounts.is_paginated());
         assert_eq!(paginated_accounts.items().len(), 5);
-        
+
         // Test conversion to PaginatedResponse for API compatibility
         let paginated_response = all_accounts.to_paginated_response();
         assert_eq!(paginated_response.items.len(), 10);
         assert_eq!(paginated_response.total_count, 10);
         assert_eq!(paginated_response.page, 1);
         assert_eq!(paginated_response.total_pages, 1);
-        
+
         // Test convenience methods still work
         let convenience_all = ledger.list_all_accounts().await.unwrap();
         assert_eq!(convenience_all.len(), 10);

--- a/src/ledger/core.rs
+++ b/src/ledger/core.rs
@@ -91,28 +91,6 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         Ok(response.into_items())
     }
 
-    /// Convenience method: List accounts with pagination
-    pub async fn list_accounts_paginated(
-        &self,
-        pagination: PaginationParams,
-    ) -> LedgerResult<PaginatedResponse<Account>> {
-        let response = self.account_manager
-            .list_accounts(PaginationOption::Paginated(pagination))
-            .await?;
-        Ok(response.to_paginated_response())
-    }
-
-    /// Convenience method: List accounts by type with pagination
-    pub async fn list_accounts_by_type_paginated(
-        &self,
-        account_type: AccountType,
-        pagination: PaginationParams,
-    ) -> LedgerResult<PaginatedResponse<Account>> {
-        let response = self.account_manager
-            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
-            .await?;
-        Ok(response.to_paginated_response())
-    }
 
     /// Update an account
     pub async fn update_account(&mut self, account: &Account) -> LedgerResult<()> {
@@ -189,32 +167,6 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         Ok(response.into_items())
     }
 
-    /// Convenience method: Get transactions with pagination within a date range
-    pub async fn get_transactions_paginated(
-        &self,
-        start_date: Option<NaiveDate>,
-        end_date: Option<NaiveDate>,
-        pagination: PaginationParams,
-    ) -> LedgerResult<PaginatedResponse<Transaction>> {
-        let response = self.transaction_manager
-            .get_transactions(start_date, end_date, PaginationOption::Paginated(pagination))
-            .await?;
-        Ok(response.to_paginated_response())
-    }
-
-    /// Convenience method: Get transactions for a specific account with pagination
-    pub async fn get_account_transactions_paginated(
-        &self,
-        account_id: &str,
-        start_date: Option<NaiveDate>,
-        end_date: Option<NaiveDate>,
-        pagination: PaginationParams,
-    ) -> LedgerResult<PaginatedResponse<Transaction>> {
-        let response = self.transaction_manager
-            .get_account_transactions(account_id, start_date, end_date, PaginationOption::Paginated(pagination))
-            .await?;
-        Ok(response.to_paginated_response())
-    }
 
     /// Update a transaction
     pub async fn update_transaction(&mut self, transaction: &Transaction) -> LedgerResult<()> {
@@ -591,9 +543,10 @@ mod tests {
         assert_eq!(all_result.items().len(), 25);
         assert!(!all_result.is_paginated());
 
-        // Test pagination with default page size
+        // Test pagination with default page size using unified API
         let pagination = PaginationParams::default(); // page: 1, page_size: 50
-        let result = ledger.list_accounts_paginated(pagination).await.unwrap();
+        let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let result = result.to_paginated_response();
 
         assert_eq!(result.items.len(), 25); // All accounts fit in one page
         assert_eq!(result.total_count, 25);
@@ -609,9 +562,10 @@ mod tests {
         assert!(unified_result.is_paginated());
         assert_eq!(unified_result.items().len(), 10);
 
-        // Test pagination with smaller page size (backward compatibility)
+        // Test pagination with smaller page size using unified API
         let pagination = PaginationParams::new(1, 10).unwrap();
-        let page1 = ledger.list_accounts_paginated(pagination).await.unwrap();
+        let page1_response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let page1 = page1_response.to_paginated_response();
 
         assert_eq!(page1.items.len(), 10);
         assert_eq!(page1.total_count, 25);
@@ -623,7 +577,8 @@ mod tests {
 
         // Test second page
         let pagination = PaginationParams::new(2, 10).unwrap();
-        let page2 = ledger.list_accounts_paginated(pagination).await.unwrap();
+        let page2_response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let page2 = page2_response.to_paginated_response();
 
         assert_eq!(page2.items.len(), 10);
         assert_eq!(page2.total_count, 25);
@@ -633,7 +588,8 @@ mod tests {
 
         // Test last page
         let pagination = PaginationParams::new(3, 10).unwrap();
-        let page3 = ledger.list_accounts_paginated(pagination).await.unwrap();
+        let page3_response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await.unwrap();
+        let page3 = page3_response.to_paginated_response();
 
         assert_eq!(page3.items.len(), 5); // Remaining accounts
         assert_eq!(page3.total_count, 25);
@@ -708,12 +664,13 @@ mod tests {
         assert!(unified_result.is_paginated());
         assert_eq!(unified_result.items().len(), 5);
 
-        // Test pagination with default settings (backward compatibility)
+        // Test pagination with default settings using unified API
         let pagination = PaginationParams::new(1, 5).unwrap();
-        let result = ledger
-            .get_transactions_paginated(None, None, pagination)
+        let result_response = ledger
+            .get_transactions(None, None, PaginationOption::Paginated(pagination))
             .await
             .unwrap();
+        let result = result_response.to_paginated_response();
 
         assert_eq!(result.items.len(), 5);
         assert_eq!(result.total_count, 15);
@@ -731,10 +688,11 @@ mod tests {
 
         // Test account-specific transactions pagination
         let pagination = PaginationParams::new(1, 10).unwrap();
-        let account_result = ledger
-            .get_account_transactions_paginated(&cash_account.id, None, None, pagination)
+        let account_result_response = ledger
+            .get_account_transactions(&cash_account.id, None, None, PaginationOption::Paginated(pagination))
             .await
             .unwrap();
+        let account_result = account_result_response.to_paginated_response();
 
         assert_eq!(account_result.items.len(), 10);
         assert_eq!(account_result.total_count, 15);
@@ -817,13 +775,9 @@ mod tests {
         assert_eq!(paginated_response.page, 1);
         assert_eq!(paginated_response.total_pages, 1);
         
-        // Test convenience methods still work (backward compatibility)
+        // Test convenience methods still work
         let convenience_all = ledger.list_all_accounts().await.unwrap();
         assert_eq!(convenience_all.len(), 10);
-        
-        let convenience_paginated = ledger.list_accounts_paginated(pagination).await.unwrap();
-        assert_eq!(convenience_paginated.items.len(), 5);
-        assert_eq!(convenience_paginated.total_count, 10);
     }
 
     #[tokio::test]

--- a/src/ledger/core.rs
+++ b/src/ledger/core.rs
@@ -55,19 +55,63 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         self.account_manager.get_account(account_id).await
     }
 
-    /// List all accounts
-    pub async fn list_accounts(&self) -> LedgerResult<Vec<Account>> {
-        self.account_manager.list_accounts().await
+    /// List all accounts with optional pagination
+    pub async fn list_accounts(
+        &self,
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Account>> {
+        self.account_manager.list_accounts(pagination).await
     }
 
-    /// List accounts by type
+    /// List accounts by type with optional pagination
     pub async fn list_accounts_by_type(
         &self,
         account_type: AccountType,
-    ) -> LedgerResult<Vec<Account>> {
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Account>> {
         self.account_manager
-            .list_accounts_by_type(account_type)
+            .list_accounts_by_type(account_type, pagination)
             .await
+    }
+
+    /// Convenience method: List all accounts without pagination
+    pub async fn list_all_accounts(&self) -> LedgerResult<Vec<Account>> {
+        let response = self.account_manager.list_accounts(PaginationOption::All).await?;
+        Ok(response.into_items())
+    }
+
+    /// Convenience method: List all accounts by type without pagination
+    pub async fn list_all_accounts_by_type(
+        &self,
+        account_type: AccountType,
+    ) -> LedgerResult<Vec<Account>> {
+        let response = self.account_manager
+            .list_accounts_by_type(account_type, PaginationOption::All)
+            .await?;
+        Ok(response.into_items())
+    }
+
+    /// Convenience method: List accounts with pagination
+    pub async fn list_accounts_paginated(
+        &self,
+        pagination: PaginationParams,
+    ) -> LedgerResult<PaginatedResponse<Account>> {
+        let response = self.account_manager
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await?;
+        Ok(response.to_paginated_response())
+    }
+
+    /// Convenience method: List accounts by type with pagination
+    pub async fn list_accounts_by_type_paginated(
+        &self,
+        account_type: AccountType,
+        pagination: PaginationParams,
+    ) -> LedgerResult<PaginatedResponse<Account>> {
+        let response = self.account_manager
+            .list_accounts_by_type(account_type, PaginationOption::Paginated(pagination))
+            .await?;
+        Ok(response.to_paginated_response())
     }
 
     /// Update an account
@@ -95,27 +139,81 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
             .await
     }
 
-    /// Get transactions for a specific account
+    /// Get transactions for a specific account with optional pagination
     pub async fn get_account_transactions(
         &self,
         account_id: &str,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>> {
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>> {
         self.transaction_manager
-            .get_account_transactions(account_id, start_date, end_date)
+            .get_account_transactions(account_id, start_date, end_date, pagination)
             .await
     }
 
-    /// Get all transactions within a date range
+    /// Get all transactions within a date range with optional pagination
     pub async fn get_transactions(
         &self,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>> {
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>> {
         self.transaction_manager
-            .get_transactions(start_date, end_date)
+            .get_transactions(start_date, end_date, pagination)
             .await
+    }
+
+    /// Convenience method: Get all transactions for a specific account
+    pub async fn get_all_account_transactions(
+        &self,
+        account_id: &str,
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+    ) -> LedgerResult<Vec<Transaction>> {
+        let response = self.transaction_manager
+            .get_account_transactions(account_id, start_date, end_date, PaginationOption::All)
+            .await?;
+        Ok(response.into_items())
+    }
+
+    /// Convenience method: Get all transactions within a date range
+    pub async fn get_all_transactions(
+        &self,
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+    ) -> LedgerResult<Vec<Transaction>> {
+        let response = self.transaction_manager
+            .get_transactions(start_date, end_date, PaginationOption::All)
+            .await?;
+        Ok(response.into_items())
+    }
+
+    /// Convenience method: Get transactions with pagination within a date range
+    pub async fn get_transactions_paginated(
+        &self,
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+        pagination: PaginationParams,
+    ) -> LedgerResult<PaginatedResponse<Transaction>> {
+        let response = self.transaction_manager
+            .get_transactions(start_date, end_date, PaginationOption::Paginated(pagination))
+            .await?;
+        Ok(response.to_paginated_response())
+    }
+
+    /// Convenience method: Get transactions for a specific account with pagination
+    pub async fn get_account_transactions_paginated(
+        &self,
+        account_id: &str,
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+        pagination: PaginationParams,
+    ) -> LedgerResult<PaginatedResponse<Transaction>> {
+        let response = self.transaction_manager
+            .get_account_transactions(account_id, start_date, end_date, PaginationOption::Paginated(pagination))
+            .await?;
+        Ok(response.to_paginated_response())
     }
 
     /// Update a transaction
@@ -281,7 +379,7 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         // would require more sophisticated analysis of transaction types
 
         let transactions = self
-            .get_transactions(Some(start_date), Some(end_date))
+            .get_transactions(Some(start_date), Some(end_date), PaginationOption::All)
             .await?;
 
         let mut operating_activities = Vec::new();
@@ -289,7 +387,7 @@ impl<S: LedgerStorage + Clone> Ledger<S> {
         let mut financing_activities = Vec::new();
 
         // Simplified categorization based on account types involved
-        for transaction in transactions {
+        for transaction in transactions.into_items() {
             let has_asset = transaction.entries.iter().any(|e| {
                 // This would need to be enhanced to check actual account types
                 e.account_id.contains("asset") || e.account_id.contains("cash")
@@ -468,5 +566,294 @@ mod tests {
             .unwrap();
 
         assert_eq!(balance_sheet.total_assets, BigDecimal::from(1000));
+    }
+
+    #[tokio::test]
+    async fn test_unified_accounts_listing() {
+        let storage = MemoryStorage::new();
+        let mut ledger = Ledger::new(storage);
+
+        // Create multiple accounts
+        for i in 1..=25 {
+            ledger
+                .create_account(
+                    format!("account_{}", i),
+                    format!("Test Account {}", i),
+                    AccountType::Asset,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        // Test getting all accounts without pagination
+        let all_result = ledger.list_accounts(PaginationOption::All).await.unwrap();
+        assert_eq!(all_result.items().len(), 25);
+        assert!(!all_result.is_paginated());
+
+        // Test pagination with default page size
+        let pagination = PaginationParams::default(); // page: 1, page_size: 50
+        let result = ledger.list_accounts_paginated(pagination).await.unwrap();
+
+        assert_eq!(result.items.len(), 25); // All accounts fit in one page
+        assert_eq!(result.total_count, 25);
+        assert_eq!(result.page, 1);
+        assert_eq!(result.page_size, 50);
+        assert_eq!(result.total_pages, 1);
+        assert!(!result.has_next);
+        assert!(!result.has_previous);
+
+        // Test unified API with paginated option
+        let pagination_option = PaginationOption::Paginated(PaginationParams::new(1, 10).unwrap());
+        let unified_result = ledger.list_accounts(pagination_option).await.unwrap();
+        assert!(unified_result.is_paginated());
+        assert_eq!(unified_result.items().len(), 10);
+
+        // Test pagination with smaller page size (backward compatibility)
+        let pagination = PaginationParams::new(1, 10).unwrap();
+        let page1 = ledger.list_accounts_paginated(pagination).await.unwrap();
+
+        assert_eq!(page1.items.len(), 10);
+        assert_eq!(page1.total_count, 25);
+        assert_eq!(page1.page, 1);
+        assert_eq!(page1.page_size, 10);
+        assert_eq!(page1.total_pages, 3);
+        assert!(page1.has_next);
+        assert!(!page1.has_previous);
+
+        // Test second page
+        let pagination = PaginationParams::new(2, 10).unwrap();
+        let page2 = ledger.list_accounts_paginated(pagination).await.unwrap();
+
+        assert_eq!(page2.items.len(), 10);
+        assert_eq!(page2.total_count, 25);
+        assert_eq!(page2.page, 2);
+        assert!(page2.has_next);
+        assert!(page2.has_previous);
+
+        // Test last page
+        let pagination = PaginationParams::new(3, 10).unwrap();
+        let page3 = ledger.list_accounts_paginated(pagination).await.unwrap();
+
+        assert_eq!(page3.items.len(), 5); // Remaining accounts
+        assert_eq!(page3.total_count, 25);
+        assert_eq!(page3.page, 3);
+        assert!(!page3.has_next);
+        assert!(page3.has_previous);
+
+        // Verify no overlapping items between pages
+        let page1_ids: Vec<_> = page1.items.iter().map(|a| &a.id).collect();
+        let page2_ids: Vec<_> = page2.items.iter().map(|a| &a.id).collect();
+        let page3_ids: Vec<_> = page3.items.iter().map(|a| &a.id).collect();
+
+        // No IDs should overlap
+        for id in &page1_ids {
+            assert!(!page2_ids.contains(id));
+            assert!(!page3_ids.contains(id));
+        }
+        for id in &page2_ids {
+            assert!(!page3_ids.contains(id));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unified_transactions_listing() {
+        let storage = MemoryStorage::new();
+        let mut ledger = Ledger::new(storage);
+
+        // Create accounts
+        let cash_account = ledger
+            .create_account(
+                "cash".to_string(),
+                "Cash".to_string(),
+                AccountType::Asset,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let revenue_account = ledger
+            .create_account(
+                "revenue".to_string(),
+                "Revenue".to_string(),
+                AccountType::Income,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Create multiple transactions
+        for i in 1..=15 {
+            let transaction = crate::ledger::transaction::patterns::create_sales_transaction(
+                format!("txn_{}", i),
+                chrono::NaiveDate::from_ymd_opt(2024, 1, i).unwrap(),
+                format!("Transaction {}", i),
+                cash_account.id.clone(),
+                revenue_account.id.clone(),
+                BigDecimal::from(100 * i),
+            )
+            .unwrap();
+
+            ledger.record_transaction(transaction).await.unwrap();
+        }
+
+        // Test getting all transactions without pagination
+        let all_result = ledger.get_transactions(None, None, PaginationOption::All).await.unwrap();
+        assert_eq!(all_result.items().len(), 15);
+        assert!(!all_result.is_paginated());
+
+        // Test unified API with pagination
+        let pagination_option = PaginationOption::Paginated(PaginationParams::new(1, 5).unwrap());
+        let unified_result = ledger.get_transactions(None, None, pagination_option).await.unwrap();
+        assert!(unified_result.is_paginated());
+        assert_eq!(unified_result.items().len(), 5);
+
+        // Test pagination with default settings (backward compatibility)
+        let pagination = PaginationParams::new(1, 5).unwrap();
+        let result = ledger
+            .get_transactions_paginated(None, None, pagination)
+            .await
+            .unwrap();
+
+        assert_eq!(result.items.len(), 5);
+        assert_eq!(result.total_count, 15);
+        assert_eq!(result.page, 1);
+        assert_eq!(result.page_size, 5);
+        assert_eq!(result.total_pages, 3);
+        assert!(result.has_next);
+        assert!(!result.has_previous);
+
+        // Verify transactions are sorted by date descending
+        let dates: Vec<_> = result.items.iter().map(|t| t.date).collect();
+        for i in 1..dates.len() {
+            assert!(dates[i - 1] >= dates[i]);
+        }
+
+        // Test account-specific transactions pagination
+        let pagination = PaginationParams::new(1, 10).unwrap();
+        let account_result = ledger
+            .get_account_transactions_paginated(&cash_account.id, None, None, pagination)
+            .await
+            .unwrap();
+
+        assert_eq!(account_result.items.len(), 10);
+        assert_eq!(account_result.total_count, 15);
+
+        // All transactions should affect the cash account
+        for txn in &account_result.items {
+            assert!(txn
+                .entries
+                .iter()
+                .any(|e| e.account_id == cash_account.id));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pagination_parameters_validation() {
+        // Test invalid page number
+        let result = PaginationParams::new(0, 10);
+        assert!(result.is_err());
+
+        // Test invalid page size (too small)
+        let result = PaginationParams::new(1, 0);
+        assert!(result.is_err());
+
+        // Test invalid page size (too large)
+        let result = PaginationParams::new(1, 1001);
+        assert!(result.is_err());
+
+        // Test valid parameters
+        let result = PaginationParams::new(1, 50);
+        assert!(result.is_ok());
+
+        let params = result.unwrap();
+        assert_eq!(params.offset(), 0);
+        assert_eq!(params.limit(), 50);
+
+        // Test offset calculation
+        let params = PaginationParams::new(3, 20).unwrap();
+        assert_eq!(params.offset(), 40); // (3-1) * 20
+        assert_eq!(params.limit(), 20);
+    }
+
+    #[tokio::test]
+    async fn test_unified_api_optimization() {
+        let storage = MemoryStorage::new();
+        let mut ledger = Ledger::new(storage);
+
+        // Create test accounts
+        for i in 1..=10 {
+            ledger
+                .create_account(
+                    format!("acc_{}", i),
+                    format!("Account {}", i),
+                    AccountType::Asset,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        // Test that single unified method can handle both cases
+        
+        // Case 1: Get all items (no pagination)
+        let all_accounts = ledger.list_accounts(PaginationOption::All).await.unwrap();
+        assert!(!all_accounts.is_paginated());
+        assert_eq!(all_accounts.items().len(), 10);
+        
+        // Case 2: Get paginated results
+        let pagination = PaginationParams::new(1, 5).unwrap();
+        let paginated_accounts = ledger
+            .list_accounts(PaginationOption::Paginated(pagination))
+            .await
+            .unwrap();
+        assert!(paginated_accounts.is_paginated());
+        assert_eq!(paginated_accounts.items().len(), 5);
+        
+        // Test conversion to PaginatedResponse for API compatibility
+        let paginated_response = all_accounts.to_paginated_response();
+        assert_eq!(paginated_response.items.len(), 10);
+        assert_eq!(paginated_response.total_count, 10);
+        assert_eq!(paginated_response.page, 1);
+        assert_eq!(paginated_response.total_pages, 1);
+        
+        // Test convenience methods still work (backward compatibility)
+        let convenience_all = ledger.list_all_accounts().await.unwrap();
+        assert_eq!(convenience_all.len(), 10);
+        
+        let convenience_paginated = ledger.list_accounts_paginated(pagination).await.unwrap();
+        assert_eq!(convenience_paginated.items.len(), 5);
+        assert_eq!(convenience_paginated.total_count, 10);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_response_metadata() {
+        // Test with exact division
+        let response = PaginatedResponse::new(vec![1, 2, 3], 2, 3, 9);
+        assert_eq!(response.total_pages, 3);
+        assert!(response.has_previous);
+        assert!(response.has_next);
+
+        // Test first page
+        let response = PaginatedResponse::new(vec![1, 2, 3], 1, 3, 9);
+        assert!(!response.has_previous);
+        assert!(response.has_next);
+
+        // Test last page
+        let response = PaginatedResponse::new(vec![7, 8, 9], 3, 3, 9);
+        assert!(response.has_previous);
+        assert!(!response.has_next);
+
+        // Test single page
+        let response = PaginatedResponse::new(vec![1, 2], 1, 5, 2);
+        assert_eq!(response.total_pages, 1);
+        assert!(!response.has_previous);
+        assert!(!response.has_next);
+
+        // Test empty result
+        let response: PaginatedResponse<i32> = PaginatedResponse::new(vec![], 1, 10, 0);
+        assert_eq!(response.total_pages, 1);
+        assert!(!response.has_previous);
+        assert!(!response.has_next);
     }
 }

--- a/src/ledger/transaction.rs
+++ b/src/ledger/transaction.rs
@@ -116,7 +116,9 @@ impl<S: LedgerStorage> TransactionManager<S> {
         end_date: Option<NaiveDate>,
         pagination: PaginationOption,
     ) -> LedgerResult<ListResponse<Transaction>> {
-        self.storage.get_transactions(start_date, end_date, pagination).await
+        self.storage
+            .get_transactions(start_date, end_date, pagination)
+            .await
     }
 
     /// Update a transaction (requires reversing old entries and applying new ones)

--- a/src/ledger/transaction.rs
+++ b/src/ledger/transaction.rs
@@ -96,25 +96,27 @@ impl<S: LedgerStorage> TransactionManager<S> {
             .ok_or_else(|| LedgerError::TransactionNotFound(transaction_id.to_string()))
     }
 
-    /// Get transactions for a specific account
+    /// Get transactions for a specific account with optional pagination
     pub async fn get_account_transactions(
         &self,
         account_id: &str,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>> {
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>> {
         self.storage
-            .get_account_transactions(account_id, start_date, end_date)
+            .get_account_transactions(account_id, start_date, end_date, pagination)
             .await
     }
 
-    /// Get all transactions within a date range
+    /// Get all transactions within a date range with optional pagination
     pub async fn get_transactions(
         &self,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>> {
-        self.storage.get_transactions(start_date, end_date).await
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>> {
+        self.storage.get_transactions(start_date, end_date, pagination).await
     }
 
     /// Update a transaction (requires reversing old entries and applying new ones)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,9 @@
 //! let pagination = PaginationParams::new(1, 50)?;
 //! let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
 //! let accounts = result.to_paginated_response();
-//! println!("Total accounts: {}, Current page: {} of {}", 
-//!          accounts.total_count, 
-//!          accounts.page, 
+//! println!("Total accounts: {}, Current page: {} of {}",
+//!          accounts.total_count,
+//!          accounts.page,
 //!          accounts.total_pages);
 //! # Ok(())
 //! # }
@@ -67,10 +67,10 @@
 //! let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
 //! let result = result.to_paginated_response();
 //!
-//! println!("Page {} of {} (showing {} of {} total accounts)", 
-//!          result.page, 
+//! println!("Page {} of {} (showing {} of {} total accounts)",
+//!          result.page,
 //!          result.total_pages,
-//!          result.items.len(), 
+//!          result.items.len(),
 //!          result.total_count);
 //!
 //! // Check if there are more pages
@@ -106,9 +106,9 @@
 //!
 //! // Get transactions for a specific account with pagination
 //! let account_txns = ledger.get_account_transactions(
-//!     "cash", 
-//!     start_date, 
-//!     end_date, 
+//!     "cash",
+//!     start_date,
+//!     end_date,
 //!     PaginationOption::Paginated(pagination)
 //! ).await?;
 //! # Ok(())
@@ -137,13 +137,13 @@
 //! println!("Total pages: {}", result.total_pages);     // e.g., 3
 //! println!("Has next page: {}", result.has_next);      // true
 //! println!("Has previous page: {}", result.has_previous); // true
-//! 
+//!
 //! // Use metadata to build navigation
 //! if result.has_previous {
 //!     println!("Previous page available");
 //! }
 //! if result.has_next {
-//!     println!("Next page available"); 
+//!     println!("Next page available");
 //! }
 //! # Ok(())
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! ## Quick Start
 //!
 //! ```rust
-//! use accounting_core::{Ledger, AccountType, PaginationParams};
+//! use accounting_core::{Ledger, AccountType, PaginationOption, PaginationParams};
 //! use accounting_core::utils::memory_storage::MemoryStorage;
 //! use bigdecimal::BigDecimal;
 //! use chrono::NaiveDate;
@@ -36,7 +36,9 @@
 //! ).await?;
 //!
 //! // List all accounts with pagination (default: page 1, 50 items per page)
-//! let accounts = ledger.list_accounts_paginated(PaginationParams::default()).await?;
+//! let pagination = PaginationParams::new(1, 50)?;
+//! let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+//! let accounts = result.to_paginated_response();
 //! println!("Total accounts: {}, Current page: {} of {}", 
 //!          accounts.total_count, 
 //!          accounts.page, 
@@ -52,7 +54,7 @@
 //! ### Basic Pagination
 //!
 //! ```rust
-//! use accounting_core::{Ledger, PaginationParams, AccountType};
+//! use accounting_core::{Ledger, PaginationOption, PaginationParams, AccountType};
 //! use accounting_core::utils::memory_storage::MemoryStorage;
 //!
 //! # #[tokio::main]
@@ -62,7 +64,8 @@
 //!
 //! // Get first page with 10 accounts per page
 //! let pagination = PaginationParams::new(1, 10)?;
-//! let result = ledger.list_accounts_paginated(pagination).await?;
+//! let result = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+//! let result = result.to_paginated_response();
 //!
 //! println!("Page {} of {} (showing {} of {} total accounts)", 
 //!          result.page, 
@@ -73,7 +76,7 @@
 //! // Check if there are more pages
 //! if result.has_next {
 //!     let next_page = PaginationParams::new(2, 10)?;
-//!     let next_result = ledger.list_accounts_paginated(next_page).await?;
+//!     let next_result = ledger.list_accounts(PaginationOption::Paginated(next_page)).await?;
 //!     // Process next page...
 //! }
 //! # Ok(())
@@ -83,7 +86,7 @@
 //! ### Filtered Pagination
 //!
 //! ```rust
-//! use accounting_core::{Ledger, PaginationParams, AccountType};
+//! use accounting_core::{Ledger, PaginationOption, PaginationParams, AccountType};
 //! use accounting_core::utils::memory_storage::MemoryStorage;
 //! use chrono::NaiveDate;
 //!
@@ -94,19 +97,19 @@
 //!
 //! // Get only Asset accounts with pagination
 //! let pagination = PaginationParams::new(1, 20)?;
-//! let assets = ledger.list_accounts_by_type_paginated(AccountType::Asset, pagination).await?;
+//! let assets = ledger.list_accounts_by_type(AccountType::Asset, PaginationOption::Paginated(pagination)).await?;
 //!
 //! // Get transactions for a specific date range with pagination
 //! let start_date = NaiveDate::from_ymd_opt(2024, 1, 1);
 //! let end_date = NaiveDate::from_ymd_opt(2024, 12, 31);
-//! let transactions = ledger.get_transactions_paginated(start_date, end_date, pagination).await?;
+//! let transactions = ledger.get_transactions(start_date, end_date, PaginationOption::Paginated(pagination)).await?;
 //!
 //! // Get transactions for a specific account with pagination
-//! let account_txns = ledger.get_account_transactions_paginated(
+//! let account_txns = ledger.get_account_transactions(
 //!     "cash", 
 //!     start_date, 
 //!     end_date, 
-//!     pagination
+//!     PaginationOption::Paginated(pagination)
 //! ).await?;
 //! # Ok(())
 //! # }
@@ -117,14 +120,15 @@
 //! All paginated responses include comprehensive metadata for building user interfaces:
 //!
 //! ```rust
-//! # use accounting_core::{Ledger, PaginationParams};
+//! # use accounting_core::{Ledger, PaginationOption, PaginationParams};
 //! # use accounting_core::utils::memory_storage::MemoryStorage;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let storage = MemoryStorage::new();
 //! # let ledger = Ledger::new(storage);
 //! let pagination = PaginationParams::new(2, 10)?;
-//! let result = ledger.list_accounts_paginated(pagination).await?;
+//! let response = ledger.list_accounts(PaginationOption::Paginated(pagination)).await?;
+//! let result = response.to_paginated_response();
 //!
 //! // Access pagination metadata
 //! println!("Current page: {}", result.page);           // 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! - **Double-entry bookkeeping**: Complete transaction validation and balance tracking
 //! - **Account management**: Support for Assets, Liabilities, Equity, Income, and Expense accounts
+//! - **Paginated responses**: Efficient pagination for large datasets with comprehensive metadata
 //! - **GST calculations**: Indian GST compliance with CGST/SGST/IGST support
 //! - **Financial reporting**: Balance sheets, income statements, and trial balance generation
 //! - **Reconciliation**: Bank statement and payment gateway reconciliation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,142 @@
 //! ## Quick Start
 //!
 //! ```rust
-//! use accounting_core::{Ledger, Account, AccountType, Transaction, Entry, EntryType};
+//! use accounting_core::{Ledger, AccountType, PaginationParams};
+//! use accounting_core::utils::memory_storage::MemoryStorage;
 //! use bigdecimal::BigDecimal;
 //! use chrono::NaiveDate;
 //!
-//! // This example shows basic usage - you need to implement LedgerStorage trait
-//! // let storage = YourStorageImplementation::new();
-//! // let mut ledger = Ledger::new(storage);
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create a ledger with in-memory storage (for production, use a database storage)
+//! let storage = MemoryStorage::new();
+//! let mut ledger = Ledger::new(storage);
+//!
+//! // Create a cash account
+//! let cash_account = ledger.create_account(
+//!     "cash".to_string(),
+//!     "Cash Account".to_string(),
+//!     AccountType::Asset,
+//!     None,
+//! ).await?;
+//!
+//! // List all accounts with pagination (default: page 1, 50 items per page)
+//! let accounts = ledger.list_accounts_paginated(PaginationParams::default()).await?;
+//! println!("Total accounts: {}, Current page: {} of {}", 
+//!          accounts.total_count, 
+//!          accounts.page, 
+//!          accounts.total_pages);
+//! # Ok(())
+//! # }
 //! ```
+//!
+//! ## Pagination Support
+//!
+//! The library provides comprehensive pagination support for both accounts and transactions:
+//!
+//! ### Basic Pagination
+//!
+//! ```rust
+//! use accounting_core::{Ledger, PaginationParams, AccountType};
+//! use accounting_core::utils::memory_storage::MemoryStorage;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let storage = MemoryStorage::new();
+//! let ledger = Ledger::new(storage);
+//!
+//! // Get first page with 10 accounts per page
+//! let pagination = PaginationParams::new(1, 10)?;
+//! let result = ledger.list_accounts_paginated(pagination).await?;
+//!
+//! println!("Page {} of {} (showing {} of {} total accounts)", 
+//!          result.page, 
+//!          result.total_pages,
+//!          result.items.len(), 
+//!          result.total_count);
+//!
+//! // Check if there are more pages
+//! if result.has_next {
+//!     let next_page = PaginationParams::new(2, 10)?;
+//!     let next_result = ledger.list_accounts_paginated(next_page).await?;
+//!     // Process next page...
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Filtered Pagination
+//!
+//! ```rust
+//! use accounting_core::{Ledger, PaginationParams, AccountType};
+//! use accounting_core::utils::memory_storage::MemoryStorage;
+//! use chrono::NaiveDate;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let storage = MemoryStorage::new();
+//! let ledger = Ledger::new(storage);
+//!
+//! // Get only Asset accounts with pagination
+//! let pagination = PaginationParams::new(1, 20)?;
+//! let assets = ledger.list_accounts_by_type_paginated(AccountType::Asset, pagination).await?;
+//!
+//! // Get transactions for a specific date range with pagination
+//! let start_date = NaiveDate::from_ymd_opt(2024, 1, 1);
+//! let end_date = NaiveDate::from_ymd_opt(2024, 12, 31);
+//! let transactions = ledger.get_transactions_paginated(start_date, end_date, pagination).await?;
+//!
+//! // Get transactions for a specific account with pagination
+//! let account_txns = ledger.get_account_transactions_paginated(
+//!     "cash", 
+//!     start_date, 
+//!     end_date, 
+//!     pagination
+//! ).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Pagination Metadata
+//!
+//! All paginated responses include comprehensive metadata for building user interfaces:
+//!
+//! ```rust
+//! # use accounting_core::{Ledger, PaginationParams};
+//! # use accounting_core::utils::memory_storage::MemoryStorage;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # let storage = MemoryStorage::new();
+//! # let ledger = Ledger::new(storage);
+//! let pagination = PaginationParams::new(2, 10)?;
+//! let result = ledger.list_accounts_paginated(pagination).await?;
+//!
+//! // Access pagination metadata
+//! println!("Current page: {}", result.page);           // 2
+//! println!("Page size: {}", result.page_size);         // 10
+//! println!("Total items: {}", result.total_count);     // e.g., 25
+//! println!("Total pages: {}", result.total_pages);     // e.g., 3
+//! println!("Has next page: {}", result.has_next);      // true
+//! println!("Has previous page: {}", result.has_previous); // true
+//! 
+//! // Use metadata to build navigation
+//! if result.has_previous {
+//!     println!("Previous page available");
+//! }
+//! if result.has_next {
+//!     println!("Next page available"); 
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Examples
+//!
+//! Check out the comprehensive examples in the `examples/` directory:
+//!
+//! - `pagination_demo.rs` - Complete pagination functionality walkthrough
+//! - `api_pagination_patterns.rs` - REST API and GraphQL integration patterns
+//! - `web_integration.rs` - Web framework integration examples
 
 pub mod ledger;
 pub mod reconciliation;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -20,8 +20,12 @@ pub trait LedgerStorage: Send + Sync {
     /// Get an account by ID
     async fn get_account(&self, account_id: &str) -> LedgerResult<Option<Account>>;
 
-    /// List all accounts, optionally filtered by type
-    async fn list_accounts(&self, account_type: Option<AccountType>) -> LedgerResult<Vec<Account>>;
+    /// List accounts with optional pagination and filtering
+    async fn list_accounts(
+        &self,
+        account_type: Option<AccountType>,
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Account>>;
 
     /// Update an account
     async fn update_account(&mut self, account: &Account) -> LedgerResult<()>;
@@ -35,20 +39,22 @@ pub trait LedgerStorage: Send + Sync {
     /// Get a transaction by ID
     async fn get_transaction(&self, transaction_id: &str) -> LedgerResult<Option<Transaction>>;
 
-    /// List transactions for a specific account
+    /// List transactions for a specific account with optional pagination
     async fn get_account_transactions(
         &self,
         account_id: &str,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>>;
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>>;
 
-    /// List all transactions within a date range
+    /// List all transactions within a date range with optional pagination
     async fn get_transactions(
         &self,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>>;
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>>;
 
     /// Update a transaction
     async fn update_transaction(&mut self, transaction: &Transaction) -> LedgerResult<()>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -297,5 +297,166 @@ pub enum LedgerError {
     Validation(String),
 }
 
+/// Pagination options for listing operations
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum PaginationOption {
+    /// Return all items without pagination
+    All,
+    /// Return paginated results
+    Paginated(PaginationParams),
+}
+
+impl Default for PaginationOption {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl From<PaginationParams> for PaginationOption {
+    fn from(params: PaginationParams) -> Self {
+        Self::Paginated(params)
+    }
+}
+
+/// Pagination parameters for listing operations
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PaginationParams {
+    /// Page number (starting from 1)
+    pub page: u32,
+    /// Number of items per page (max 1000)
+    pub page_size: u32,
+}
+
+impl PaginationParams {
+    /// Create new pagination parameters with validation
+    pub fn new(page: u32, page_size: u32) -> LedgerResult<Self> {
+        if page < 1 {
+            return Err(LedgerError::Validation("Page must be 1 or greater".to_string()));
+        }
+        if page_size < 1 || page_size > 1000 {
+            return Err(LedgerError::Validation("Page size must be between 1 and 1000".to_string()));
+        }
+        Ok(Self { page, page_size })
+    }
+
+    /// Get the offset for database queries
+    pub fn offset(&self) -> u32 {
+        (self.page - 1) * self.page_size
+    }
+
+    /// Get the limit for database queries
+    pub fn limit(&self) -> u32 {
+        self.page_size
+    }
+}
+
+impl Default for PaginationParams {
+    fn default() -> Self {
+        Self {
+            page: 1,
+            page_size: 50,
+        }
+    }
+}
+
+/// Unified response that can contain either all items or paginated results
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ListResponse<T> {
+    /// All items returned without pagination
+    All(Vec<T>),
+    /// Paginated results with metadata
+    Paginated(PaginatedResponse<T>),
+}
+
+impl<T> ListResponse<T> {
+    /// Get the items regardless of response type
+    pub fn items(&self) -> &Vec<T> {
+        match self {
+            Self::All(items) => items,
+            Self::Paginated(response) => &response.items,
+        }
+    }
+
+    /// Get items as owned vector
+    pub fn into_items(self) -> Vec<T> {
+        match self {
+            Self::All(items) => items,
+            Self::Paginated(response) => response.items,
+        }
+    }
+
+    /// Check if this is a paginated response
+    pub fn is_paginated(&self) -> bool {
+        matches!(self, Self::Paginated(_))
+    }
+
+    /// Get pagination metadata if available
+    pub fn pagination_info(&self) -> Option<&PaginatedResponse<T>> {
+        match self {
+            Self::All(_) => None,
+            Self::Paginated(response) => Some(response),
+        }
+    }
+
+    /// Convert to PaginatedResponse (creates artificial pagination for All)
+    pub fn to_paginated_response(self) -> PaginatedResponse<T> {
+        match self {
+            Self::All(items) => {
+                let count = items.len() as u32;
+                PaginatedResponse::new(items, 1, count, count)
+            }
+            Self::Paginated(response) => response,
+        }
+    }
+}
+
+/// Paginated response containing items and metadata
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PaginatedResponse<T> {
+    /// The items for this page
+    pub items: Vec<T>,
+    /// Current page number
+    pub page: u32,
+    /// Number of items per page
+    pub page_size: u32,
+    /// Total number of items across all pages
+    pub total_count: u32,
+    /// Total number of pages
+    pub total_pages: u32,
+    /// Whether there is a next page
+    pub has_next: bool,
+    /// Whether there is a previous page
+    pub has_previous: bool,
+}
+
+impl<T> PaginatedResponse<T> {
+    /// Create a new paginated response
+    pub fn new(
+        items: Vec<T>,
+        page: u32,
+        page_size: u32,
+        total_count: u32,
+    ) -> Self {
+        let total_pages = if total_count == 0 {
+            1
+        } else {
+            (total_count + page_size - 1) / page_size
+        };
+
+        let has_next = page < total_pages;
+        let has_previous = page > 1;
+
+        Self {
+            items,
+            page,
+            page_size,
+            total_count,
+            total_pages,
+            has_next,
+            has_previous,
+        }
+    }
+}
+
 /// Result type for ledger operations
 pub type LedgerResult<T> = Result<T, LedgerError>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -331,10 +331,14 @@ impl PaginationParams {
     /// Create new pagination parameters with validation
     pub fn new(page: u32, page_size: u32) -> LedgerResult<Self> {
         if page < 1 {
-            return Err(LedgerError::Validation("Page must be 1 or greater".to_string()));
+            return Err(LedgerError::Validation(
+                "Page must be 1 or greater".to_string(),
+            ));
         }
         if !(1..=1000).contains(&page_size) {
-            return Err(LedgerError::Validation("Page size must be between 1 and 1000".to_string()));
+            return Err(LedgerError::Validation(
+                "Page size must be between 1 and 1000".to_string(),
+            ));
         }
         Ok(Self { page, page_size })
     }
@@ -431,12 +435,7 @@ pub struct PaginatedResponse<T> {
 
 impl<T> PaginatedResponse<T> {
     /// Create a new paginated response
-    pub fn new(
-        items: Vec<T>,
-        page: u32,
-        page_size: u32,
-        total_count: u32,
-    ) -> Self {
+    pub fn new(items: Vec<T>, page: u32, page_size: u32, total_count: u32) -> Self {
         let total_pages = if total_count == 0 {
             1
         } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -333,7 +333,7 @@ impl PaginationParams {
         if page < 1 {
             return Err(LedgerError::Validation("Page must be 1 or greater".to_string()));
         }
-        if page_size < 1 || page_size > 1000 {
+        if !(1..=1000).contains(&page_size) {
             return Err(LedgerError::Validation("Page size must be between 1 and 1000".to_string()));
         }
         Ok(Self { page, page_size })
@@ -440,7 +440,7 @@ impl<T> PaginatedResponse<T> {
         let total_pages = if total_count == 0 {
             1
         } else {
-            (total_count + page_size - 1) / page_size
+            total_count.div_ceil(page_size)
         };
 
         let has_next = page < total_pages;

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Account types following standard accounting principles
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AccountType {
     /// Assets - what the business owns (Cash, Inventory, Equipment, etc.)
     Asset,

--- a/src/utils/memory_storage.rs
+++ b/src/utils/memory_storage.rs
@@ -52,9 +52,13 @@ impl LedgerStorage for MemoryStorage {
         Ok(self.accounts.read().unwrap().get(account_id).cloned())
     }
 
-    async fn list_accounts(&self, account_type: Option<AccountType>) -> LedgerResult<Vec<Account>> {
+    async fn list_accounts(
+        &self,
+        account_type: Option<AccountType>,
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Account>> {
         let accounts = self.accounts.read().unwrap();
-        let filtered: Vec<Account> = accounts
+        let mut filtered: Vec<Account> = accounts
             .values()
             .filter(|account| {
                 account_type
@@ -63,7 +67,34 @@ impl LedgerStorage for MemoryStorage {
             })
             .cloned()
             .collect();
-        Ok(filtered)
+
+        // Sort by account ID for consistent results
+        filtered.sort_by(|a, b| a.id.cmp(&b.id));
+
+        match pagination {
+            PaginationOption::All => Ok(ListResponse::All(filtered)),
+            PaginationOption::Paginated(pagination_params) => {
+                let total_count = filtered.len() as u32;
+                let start_index = pagination_params.offset() as usize;
+                let end_index = std::cmp::min(
+                    start_index + pagination_params.limit() as usize,
+                    filtered.len(),
+                );
+
+                let items = if start_index < filtered.len() {
+                    filtered[start_index..end_index].to_vec()
+                } else {
+                    Vec::new()
+                };
+
+                Ok(ListResponse::Paginated(PaginatedResponse::new(
+                    items,
+                    pagination_params.page,
+                    pagination_params.page_size,
+                    total_count,
+                )))
+            }
+        }
     }
 
     async fn update_account(&mut self, account: &Account) -> LedgerResult<()> {
@@ -108,9 +139,10 @@ impl LedgerStorage for MemoryStorage {
         account_id: &str,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>> {
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>> {
         let transactions = self.transactions.read().unwrap();
-        let filtered: Vec<Transaction> = transactions
+        let mut filtered: Vec<Transaction> = transactions
             .values()
             .filter(|txn| {
                 // Check if transaction affects the account
@@ -138,16 +170,46 @@ impl LedgerStorage for MemoryStorage {
             })
             .cloned()
             .collect();
-        Ok(filtered)
+
+        // Sort by date descending, then by ID for consistent results
+        filtered.sort_by(|a, b| {
+            b.date.cmp(&a.date).then_with(|| a.id.cmp(&b.id))
+        });
+
+        match pagination {
+            PaginationOption::All => Ok(ListResponse::All(filtered)),
+            PaginationOption::Paginated(pagination_params) => {
+                let total_count = filtered.len() as u32;
+                let start_index = pagination_params.offset() as usize;
+                let end_index = std::cmp::min(
+                    start_index + pagination_params.limit() as usize,
+                    filtered.len(),
+                );
+
+                let items = if start_index < filtered.len() {
+                    filtered[start_index..end_index].to_vec()
+                } else {
+                    Vec::new()
+                };
+
+                Ok(ListResponse::Paginated(PaginatedResponse::new(
+                    items,
+                    pagination_params.page,
+                    pagination_params.page_size,
+                    total_count,
+                )))
+            }
+        }
     }
 
     async fn get_transactions(
         &self,
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
-    ) -> LedgerResult<Vec<Transaction>> {
+        pagination: PaginationOption,
+    ) -> LedgerResult<ListResponse<Transaction>> {
         let transactions = self.transactions.read().unwrap();
-        let filtered: Vec<Transaction> = transactions
+        let mut filtered: Vec<Transaction> = transactions
             .values()
             .filter(|txn| {
                 if let Some(start) = start_date {
@@ -164,7 +226,36 @@ impl LedgerStorage for MemoryStorage {
             })
             .cloned()
             .collect();
-        Ok(filtered)
+
+        // Sort by date descending, then by ID for consistent results
+        filtered.sort_by(|a, b| {
+            b.date.cmp(&a.date).then_with(|| a.id.cmp(&b.id))
+        });
+
+        match pagination {
+            PaginationOption::All => Ok(ListResponse::All(filtered)),
+            PaginationOption::Paginated(pagination_params) => {
+                let total_count = filtered.len() as u32;
+                let start_index = pagination_params.offset() as usize;
+                let end_index = std::cmp::min(
+                    start_index + pagination_params.limit() as usize,
+                    filtered.len(),
+                );
+
+                let items = if start_index < filtered.len() {
+                    filtered[start_index..end_index].to_vec()
+                } else {
+                    Vec::new()
+                };
+
+                Ok(ListResponse::Paginated(PaginatedResponse::new(
+                    items,
+                    pagination_params.page,
+                    pagination_params.page_size,
+                    total_count,
+                )))
+            }
+        }
     }
 
     async fn update_transaction(&mut self, transaction: &Transaction) -> LedgerResult<()> {
@@ -216,10 +307,10 @@ impl LedgerStorage for MemoryStorage {
         // Calculate balance as of specific date
         let mut balance = BigDecimal::from(0);
         let transactions = self
-            .get_account_transactions(account_id, None, as_of_date)
+            .get_account_transactions(account_id, None, as_of_date, PaginationOption::All)
             .await?;
 
-        for transaction in transactions {
+        for transaction in transactions.into_items() {
             for entry in transaction.entries {
                 if entry.account_id == account_id {
                     match (account.account_type.normal_balance(), entry.entry_type) {
@@ -240,12 +331,12 @@ impl LedgerStorage for MemoryStorage {
     }
 
     async fn get_trial_balance(&self, as_of_date: NaiveDate) -> LedgerResult<TrialBalance> {
-        let accounts = self.list_accounts(None).await?;
+        let accounts = self.list_accounts(None, PaginationOption::All).await?;
         let mut balances = HashMap::new();
         let mut total_debits = BigDecimal::from(0);
         let mut total_credits = BigDecimal::from(0);
 
-        for account in accounts {
+        for account in accounts.into_items() {
             let balance = self
                 .get_account_balance(&account.id, Some(as_of_date))
                 .await?;

--- a/src/utils/memory_storage.rs
+++ b/src/utils/memory_storage.rs
@@ -172,9 +172,7 @@ impl LedgerStorage for MemoryStorage {
             .collect();
 
         // Sort by date descending, then by ID for consistent results
-        filtered.sort_by(|a, b| {
-            b.date.cmp(&a.date).then_with(|| a.id.cmp(&b.id))
-        });
+        filtered.sort_by(|a, b| b.date.cmp(&a.date).then_with(|| a.id.cmp(&b.id)));
 
         match pagination {
             PaginationOption::All => Ok(ListResponse::All(filtered)),
@@ -228,9 +226,7 @@ impl LedgerStorage for MemoryStorage {
             .collect();
 
         // Sort by date descending, then by ID for consistent results
-        filtered.sort_by(|a, b| {
-            b.date.cmp(&a.date).then_with(|| a.id.cmp(&b.id))
-        });
+        filtered.sort_by(|a, b| b.date.cmp(&a.date).then_with(|| a.id.cmp(&b.id)));
 
         match pagination {
             PaginationOption::All => Ok(ListResponse::All(filtered)),
@@ -400,7 +396,7 @@ impl LedgerStorage for MemoryStorage {
         let mut result: HashMap<AccountType, Vec<AccountBalance>> = HashMap::new();
 
         for account_balance in trial_balance.balances.into_values() {
-            let account_type = account_balance.account.account_type.clone();
+            let account_type = account_balance.account.account_type;
             result
                 .entry(account_type)
                 .or_default()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -260,9 +260,9 @@ async fn test_account_hierarchy() {
 
     assert_eq!(child_account.parent_id, Some(parent_account.id));
 
-    // Test listing accounts by type
+    // Test listing accounts by type (using convenience method)
     let asset_accounts = ledger
-        .list_accounts_by_type(AccountType::Asset)
+        .list_all_accounts_by_type(AccountType::Asset)
         .await
         .unwrap();
     assert_eq!(asset_accounts.len(), 2);
@@ -318,9 +318,9 @@ async fn test_date_range_filtering() {
     ledger.record_transaction(txn1).await.unwrap();
     ledger.record_transaction(txn2).await.unwrap();
 
-    // Test date range filtering
+    // Test date range filtering (using convenience method)
     let jan_transactions = ledger
-        .get_transactions(
+        .get_all_transactions(
             Some(NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()),
             Some(NaiveDate::from_ymd_opt(2024, 1, 31).unwrap()),
         )
@@ -394,8 +394,8 @@ async fn test_memory_storage_operations() {
     assert!(retrieved.is_some());
     assert_eq!(retrieved.unwrap().name, "Test Account");
 
-    let all_accounts = storage.list_accounts(None).await.unwrap();
-    assert_eq!(all_accounts.len(), 1);
+    let all_accounts = storage.list_accounts(None, PaginationOption::All).await.unwrap();
+    assert_eq!(all_accounts.items().len(), 1);
 
     // Test transaction operations
     let transaction = TransactionBuilder::new(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,7 +4,7 @@ use accounting_core::{
     patterns,
     utils::{EnhancedAccountValidator, EnhancedTransactionValidator, MemoryStorage},
     AccountType, GstCalculator, GstCategory, GstInvoice, GstLineItem, Ledger, LedgerStorage,
-    TransactionBuilder,
+    PaginationOption, TransactionBuilder,
 };
 use bigdecimal::BigDecimal;
 use chrono::NaiveDate;
@@ -395,7 +395,7 @@ async fn test_memory_storage_operations() {
     assert_eq!(retrieved.unwrap().name, "Test Account");
 
     let all_accounts = storage.list_accounts(None, PaginationOption::All).await.unwrap();
-    assert_eq!(all_accounts.items().len(), 1);
+    assert_eq!(all_accounts.into_items().len(), 1);
 
     // Test transaction operations
     let transaction = TransactionBuilder::new(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -394,7 +394,10 @@ async fn test_memory_storage_operations() {
     assert!(retrieved.is_some());
     assert_eq!(retrieved.unwrap().name, "Test Account");
 
-    let all_accounts = storage.list_accounts(None, PaginationOption::All).await.unwrap();
+    let all_accounts = storage
+        .list_accounts(None, PaginationOption::All)
+        .await
+        .unwrap();
     assert_eq!(all_accounts.into_items().len(), 1);
 
     // Test transaction operations


### PR DESCRIPTION
- Unify listing APIs: removed separate *_paginated methods and consolidated into single listing methods that acceptOption (All or Paginated) PaginationParams.
-ce new response/types: added ListResponse and PaginatedResponse types and PaginationParams/PaginationOption structs; added convenience helpers to convert to paginated responses.
- Update traits and implementations: updated ledger, account, transaction traits and memory storage to the unified API and pagination model.
- Migrate callsites and examples: replaced old *_paginated usages with PaginationOption::Paginated/All and added .to_paginated_response()/into_items() where appropriate; updated docs and crate examples to compile with new API.
- Remove deprecated helpers: removed deprecated convenience methods with *_paginated signatures and adjusted tests accordingly.
- Add validation and metadata: include consistent pagination metadata and validation in responses.
- Fixes and cleanup: addressed Clippy warnings, improved readability (wrapped long method chains), and corrected pagination calculations (use div_ceil).