### PR TITLE
fix: eliminate TOCTOU race condition in update_account

### DIFF
--- a/src/utils/memory_storage.rs
+++ b/src/utils/memory_storage.rs
@@ -98,11 +98,9 @@ impl LedgerStorage for MemoryStorage {
     }
 
     async fn update_account(&mut self, account: &Account) -> LedgerResult<()> {
-        if self.accounts.read().unwrap().contains_key(&account.id) {
-            self.accounts
-                .write()
-                .unwrap()
-                .insert(account.id.clone(), account.clone());
+        let mut accounts = self.accounts.write().unwrap();
+        if accounts.contains_key(&account.id) {
+            accounts.insert(account.id.clone(), account.clone());
             Ok(())
         } else {
             Err(LedgerError::AccountNotFound(account.id.clone()))


### PR DESCRIPTION
Replace separate read-then-write lock pattern with a single write lock in `update_account` to atomically check existence and update the account, preventing a race where another thread could modify the map between the check and the write.